### PR TITLE
Applying minimal entity modelling

### DIFF
--- a/model/schema/sssom.yaml
+++ b/model/schema/sssom.yaml
@@ -65,9 +65,12 @@ slots:
     description: Contains a list of mapping objects
     range: mapping
     multivalued: true
+  id:
+    description: CURIE or IRI identifier
+    identifier: true
   subject_id:
     description: The ID of the subject of the mapping.
-    range: uriorcurie
+    range: entity
     required: true
     mappings:
     - owl:annotatedSource
@@ -94,7 +97,7 @@ slots:
       object of this match.
     mappings:
     - owl:annotatedProperty
-    range: uriorcurie
+    range: entity
     required: true
     slot_uri: owl:annotatedProperty
     examples:
@@ -131,7 +134,7 @@ slots:
     description: The ID of the object of the mapping.
     mappings:
     - owl:annotatedTarget
-    range: uriorcurie
+    range: entity
     required: true
     slot_uri: owl:annotatedTarget
     examples:
@@ -377,6 +380,13 @@ slots:
     description: 'SSSOM property should be mapped to:'
     range: string
 classes:
+  entity:
+    description: Represents any entity that can be mapped, such as an OWL class or
+      SKOS concept
+    mappings:
+    - rdf:Resource
+    slots:
+    - id
   mapping set:
     description: Represents a set of mappings
     slot_usage:


### PR DESCRIPTION
See also https://github.com/linkml/linkml/issues/450

The question is whether (and which) element in SSSOM should be modelled as nodes, and which as uriorcurie.

@cmungall is this the right modelling syntax?

The question that remains is what to do about all the other fields, say `creator_id`. Shall we simply switch all these to datatype `Uri`, to avoid having to deal with the ambiguity of the field (without any magic code, uriorcurie would be translated to "orcid:123"^^xsd:anyUri, rather than "http://orcid.org/123"^^xsd:anyUri when "orcid:123" is supplied in the sssom table).