### PR TITLE
Removing required as a model element (it is a metamodel element)

### DIFF
--- a/model/schema/sssom.yaml
+++ b/model/schema/sssom.yaml
@@ -365,9 +365,6 @@ slots:
       by tool providing additional informative information.
     slot_uri: rdfs:comment
     range: string
-  required:
-    description: Indicates wether the SSSOM metadata element is required
-    range: string
   metadata_element:
     description: All legal SSSOM metadata elements are subproperties of this.
     range: string


### PR DESCRIPTION
I think including `required` was a (mostly harmless) mistake?