### PR TITLE
Making match_type recommended

### DIFF
--- a/model/schema/sssom.yaml
+++ b/model/schema/sssom.yaml
@@ -165,7 +165,7 @@ slots:
   match_type:
     description: The kind of match that led to the mapping, e.g. Logical or Lexical.
     range: match_type_enum
-    required: true
+    recommended: true
     multivalued: true
     examples:
       - value: Lexical


### PR DESCRIPTION
At the moment, 4 elements in sssom are required, i.e. validation fails if they are not present:

- `subject_id`
- `object_id`
- `predicate_id`
- `match_type`

This has big ramifications for the toolkits, which will simply fail if one of the four is not present.

I hereby move forward the motion to make `match_type` `recommended` instead of `required`. This is not to diminish its importance, it's just impractical to have all our toolchains fail hard when processing simple <s,p,o> tables.

This PR will be merged on Friday 10th December unless objections.