### PR TITLE
Change w3id.org to https

### DIFF
--- a/src/linkml/sssom.yaml
+++ b/src/linkml/sssom.yaml
@@ -1,11 +1,11 @@
-id: http://w3id.org/sssom/schema/
+id: https://w3id.org/sssom/schema/
 name: sssom
 description: Datamodel for Simple Standard for Sharing Ontology Mappings (SSSOM)
 imports:
 - linkml:types
 prefixes:
   linkml: https://w3id.org/linkml/
-  sssom: http://w3id.org/sssom/
+  sssom: https://w3id.org/sssom/
   rdfs: http://www.w3.org/2000/01/rdf-schema#
   oboInOwl: http://www.geneontology.org/formats/oboInOwl#
   dce: http://purl.org/dc/elements/1.1/


### PR DESCRIPTION
This is an oversight. w3ids must be https, and should be: https://w3id.org/