### PR TITLE
Add mapping_set_title

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -251,6 +251,12 @@ slots:
   mapping_set_group:
     description: Set by the owners of the mapping registry. A way to group .
     range: string
+  mapping_set_title:
+    description: The display name of a mapping set.
+    range: string
+    slot_uri: dc:title
+    examples:
+      - value: "The Mondo-OMIM mappings by Monarch Initiative."
   mapping_set_description:
     description: A description of the mapping set.
     range: string
@@ -450,6 +456,7 @@ classes:
     - mapping_set_id
     - mapping_set_version
     - mapping_set_source
+    - mapping_set_title
     - mapping_set_description
     - creator_id
     - creator_label


### PR DESCRIPTION
Resolves #219 

- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/0.9.0/CHANGELOG.md) has been updated.

This PR adds the mapping_set_title element, which allows to capture display names for mapping sets.