### PR TITLE
Adding `mapping_source` slot to `Mapping`

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -497,6 +497,7 @@ classes:
     - object_source
     - object_source_version
     - mapping_provider
+    - mapping_source
     - mapping_cardinality
     - mapping_tool
     - mapping_tool_version


### PR DESCRIPTION
This was an oversight from a previous PR, we forgot to add that slot we defined to the `Mapping` model

Resolves [#134]

- [X] `docs/` have been added/updated if necessary
- [X] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/0.9.0/CHANGELOG.md) has been updated.

This is an oversight that should have been in https://github.com/mapping-commons/sssom/pull/135.