### PR TITLE
Add registry title and registry description slots

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -90,7 +90,7 @@ slots:
   mapping_registry_title:
     description: The title of a mapping registry.
     range: string
-  registry_description:
+  mapping_registry_description:
     description: The description of a mapping registry.
     range: string
   imports:

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -87,6 +87,12 @@ slots:
     description: The unique identifier of a mapping registry.
     range: EntityReference
     required: true
+  registry_title:
+    description: The title of a mapping registry.
+    range: string
+  registry_description:
+    description: The description of a mapping registry.
+    range: string
   imports:
     description: A list of registries that should be imported into this one.
     multivalued: true

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -533,7 +533,7 @@ classes:
     slots:
       - mapping_registry_id
       - registry_title
-      - registry_description
+      - mapping_registry_description
       - imports
       - mapping_set_references
       - documentation

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -532,7 +532,7 @@ classes:
       mapping set references, and can import other registries.
     slots:
       - mapping_registry_id
-      - registry_title
+      - mapping_registry_title
       - mapping_registry_description
       - imports
       - mapping_set_references

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -532,6 +532,8 @@ classes:
       mapping set references, and can import other registries.
     slots:
       - mapping_registry_id
+      - registry_title
+      - registry_description
       - imports
       - mapping_set_references
       - documentation

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -87,7 +87,7 @@ slots:
     description: The unique identifier of a mapping registry.
     range: EntityReference
     required: true
-  registry_title:
+  mapping_registry_title:
     description: The title of a mapping registry.
     range: string
   registry_description:


### PR DESCRIPTION
Resolves [#238, #239]

- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/0.9.0/CHANGELOG.md) has been updated.

Add two text slots, `registry_title` and `registry_description`, to mapping registry class.