### PR TITLE
Add inversion rules for SEMAPV cross-species predicates.

### DIFF
--- a/src/docs/chaining_rules.md
+++ b/src/docs/chaining_rules.md
@@ -92,6 +92,12 @@ This excludes the exact predicates for which inverse rules are redundant.
 - RI1: `(:A)-[skos:narrowMatch]->(:B)` -> `(:B)-[skos:broadMatch]->(:A)`
 - RI2: `(:A)-[skos:broadMatch]->(:B)` -> `(:B)-[skos:narrowMatch]->(:A)`
 
+### Rules for SEMAPV
+
+- RI3: `(:A)-[semapv:crossSpeciesExactMatch]->(:B)` -> `(:B)-[semapv:crossSpeciesExactMatch]->(:A)`
+- RI4: `(:A)-[semapv:crossSpeciesNarrowMatch]->(:B)` -> `(:B)-[semapv:crossSpeciesBroadMatch]->(:A)`
+- RI5: `(:A)-[semapv:crossSpeciesBroadMatch]->(:B)` -> `(:B)-[semapv:crossSpeciesNarrowMatch]->(:A)`
+
 <a id="generalisation"></a>
 
 ## Generalisation Rules


### PR DESCRIPTION
This PR updates the documentation to propose new inversion (“flipping”) rules for the cross-species predicates defined in the “semantic mapping vocabulary” (SEMAPV).

Specifically, it proposes that `semapv:crossSpeciesExactMatch` can be directly inverted, and that `semapv:crossSpeciesNarrowMatch` and `semapv:crossSpeciesBroadMatch` are mutually inverse. This follows the logic of the `skos:{exact,narrow,broad}Match` predicates upon which those cross-species variants are based.

`semapv:crossSpeciesCloseMatch` is _not_ listed on purpose; the predicate is to be implicitly considered as “non-invertible”.

- [x] `docs/` have been added/updated
- [ ] `make test` has been run locally (not applicable, documentation change only)
- [ ] tests have been added/updated (likewise)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/0.9.0/CHANGELOG.md) has been updated (deemed not necessary)