### PR TITLE
Making adding a link to a working example required when adding a new field

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ If you are proposing a change to the SSSOM metadata model, you must
 
 - [ ] provide a full, working and valid example in `examples/`
 - [ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model
+- [ ] provide a link to a the valid example in the `see_also` field of the linkml model
 
 
 [Add a description, mentioning at least relevant #ISSUE and how it was addressed. A bulleted list of all changes performed by the PR is is helpful.]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ If you are proposing a change to the SSSOM metadata model, you must
 
 - [ ] provide a full, working and valid example in `examples/`
 - [ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model
-- [ ] provide a link to a the valid example in the `see_also` field of the linkml model
+- [ ] provide a link to a valid example in the `see_also` field of the linkml model
 
 
 [Add a description, mentioning at least relevant #ISSUE and how it was addressed. A bulleted list of all changes performed by the PR is is helpful.]


### PR DESCRIPTION
This PR extends the pull request template to make adding a working example to a metadata field required.