### PR TITLE
Fix semapv namespace in SSSOM schema

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -12,7 +12,7 @@ prefixes:
   pav: http://purl.org/pav/
   prov: http://www.w3.org/ns/prov#
   skos: http://www.w3.org/2004/02/skos/core#
-  semapv: https://w3id.org/semapv/
+  semapv: https://w3id.org/semapv/vocab/
 see_also:
 - https://github.com/mapping-commons/sssom
 - https://mapping-commons.github.io/sssom/home/


### PR DESCRIPTION
The semapv namespace is wrongly documented in the LinkML model.

Instead of `https://w3id.org/semapv/` it should be `https://w3id.org/semapv/vocab`, see SEMAPV:

https://github.com/mapping-commons/semantic-mapping-vocabulary/blob/main/semapv.owl

e.g.:

https://w3id.org/semapv/vocab/CaseNormalization