### PR TITLE
Fix publication_date

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -522,6 +522,7 @@ classes:
     - mapping_provider
     - mapping_tool
     - mapping_date
+    - publication_date
     - subject_match_field
     - object_match_field
     - subject_preprocessing
@@ -561,6 +562,7 @@ classes:
     - mapping_tool
     - mapping_tool_version
     - mapping_date
+    - publication_date
     - confidence
     - curation_rule
     - curation_rule_text


### PR DESCRIPTION
Resolves #293 

A property (publication_date) was defined in SSSOM, but was not added to the SSSOM mapping and mapping set data model. Since a very similar property (mapping_date) was already defined, this change is considered a bugfix, rather than an added feature.