### PR TITLE
Add mapping_set_version to MappingSet metadata

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -521,6 +521,7 @@ classes:
     - object_source_version
     - mapping_provider
     - mapping_tool
+    - mapping_tool_version
     - mapping_date
     - subject_match_field
     - object_match_field


### PR DESCRIPTION
@gouttegd noticed that while you can provide `mapping_tool` on `MappingSet` level, you cant declare `mapping_tool_version`. This was a oversight on my part, so no need for a large review.