### PR TITLE
Add guide for tool implementors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,11 +40,14 @@ nav:
     - Workshops: workshops.md
     - Presentations: presentations.md
     - Basic Tutorial: tutorial.md
+    - Mapping Justifications: mapping-justifications.md
     - How to use mapping predicates: mapping-predicates.md
     - Overview of Chaining Rules: chaining_rules.md
     - A basic guide for the SSSOM toolkit: toolkit.md
     - 5-Star Entity Mappings - Cheatsheet: 5star-mappings.md
     - Update schema/context and release: update.md
+    - Matching tool implementation guide: matching-tool-implementation-guide.md
+    - Glossary: glossary.md
 
 site_url: https://mapping-commons.github.io/sssom/
 repo_url: https://github.com/mapping-commons/sssom/

--- a/src/docs/glossary.md
+++ b/src/docs/glossary.md
@@ -1,0 +1,3 @@
+# Glossary
+
+The glossary is currently being developed [here](https://docs.google.com/document/d/1QqR8j7szjaq6wzE9YLBnZ2kOD9eN14d3SYd312X8JjQ/edit?usp=sharing).

--- a/src/docs/mapping-justifications.md
+++ b/src/docs/mapping-justifications.md
@@ -1,0 +1,89 @@
+# Guide to using Mapping Justifications
+
+The goal of this document is to provide the user with a few pointers into the art of mapping justification construction. As of Summer 2023, the SSSOM justification system is still evolving, and will likely benefit from yoru input. Where informative metadata properties or values are missing from the [SSSOM datamodel](https://mapping-commons.github.io/sssom/) or [SEMAPV](https://mapping-commons.github.io/semantic-mapping-vocabulary/), request them on the [SSSOM](https://github.com/mapping-commons/sssom/issues) or [SEMAPV issue tracker](https://github.com/mapping-commons/semantic-mapping-vocabulary/issues) respectively.
+
+## Table of contents
+
+1. [lexical matching](#lexical-matching)
+1. [semantic similarity threshold-based matching](#semantic-matching)
+1. [mapping review](#mapping-review)
+1. Other justifications
+    1. background knowledge-based matching
+    1. composite matching
+    1. instance-based matching
+    1. lexical similarity threshold-based matching
+    1. logical reasoning
+    1. manual mapping curation
+    1. mapping chaining-based matching
+    1. mapping inversion-based matching
+    1. semantic similarity threshold-based matching
+    1. structural matching
+    1. unspecified matching
+
+
+<a id="lexical-matching"></a>
+
+## Lexical matching
+
+There are two kinds of lexical matching justifications we try to distinguish:
+
+- [semapv:LexicalMatching](https://w3id.org/semapv/vocab/LexicalMatching): The match is exact (potentially after pre-processing)
+- [semapv:LexicalSimilarityThresholdMatching](https://w3id.org/semapv/vocab/LexicalSimilarityThresholdMatching): The match is fuzzy (for example, Levenshtein distance). Note: embedding similarity, even if constructed purely of a word embedding, is considered a form of _semantic_ similarity.
+
+#### Level 1: Track the fact that the match was based on a lexical process
+
+Whenever a mapping was established by a lexical matching process, track at least that fact:
+
+- [mapping_justification](https://mapping-commons.github.io/sssom/mapping_justification/)`: `[semapv:LexicalMatching](https://w3id.org/semapv/vocab/CompositeMatching). This indicates that the mapping was determined through some form of exact lexical matching.
+
+#### Level 2: Track the specific datamodel fields involved in the matching process
+
+Regardless of which specific lexical matching justification you are working on, it is often useful to document the source field of the values used to aquire the match. For example:
+
+- [subject_match_field](https://mapping-commons.github.io/sssom/subject_match_field/)`: rdfs:label` indicates that the value of the `rdfs:label` property on the subject entity was used to establish the match.
+- [object_match_field](https://mapping-commons.github.io/sssom/object_match_field/)`: skos:prefLabel` indicates that the value of the `skos:prefLabel` property on the object entity was used to establish the match.
+- [match_string](https://mapping-commons.github.io/sssom/match_string/)`: somestring` the exact string that was used to establish the match. This is especially useful if preprocessing methods are applied, see below (Level 3).
+
+#### Level 3: Pre-processing
+
+There are many pre-processing techniques for text in the NLP literature, such as lower-casing or lemmatisation. To judge the fidelity of a match, it is often useful to document the exact techniques used.
+
+- [subject_preprocessing](https://mapping-commons.github.io/sssom/match_string/)`: semapv:BlankNormalisation` indicates that before determining the match, blank characters (spaces etc) where standardised in some way. There are plenty of preprocessing techniques already recorded in [SEMAPV](https://mapping-commons.github.io/semantic-mapping-vocabulary/), including semapv:BlankNormalisation, semapv:CaseNormalization, semapv:DiacriticsSuppression, semapv:DigitSuppression, semapv:Lemmatization, semapv:LinkStripping, semapv:PunctuationElemination, semapv:RegexRemoval, semapv:RegexReplacement, semapv:Stemming, semapv:StopWordRemoval, semapv:TermExtraction, semapv:Tokenization, but feel free to add more.
+
+However, there is one aspect that makes this process quite difficult to implement: Most matchers will blindly apply a set of normalisation techniques prior to processing, but not document which exact technique **had an effect**. It is obviously less useful to say: we applied all these 20 techniques, if only one of them was actually effectual (i.e. caused the string to change).
+
+If there is no (easy) way to keep track of which technique was effectual for any given match, we believe that it is still better to document all techniques, but doing so on `mapping set` level rather than for each individual mappings (to keep the mapping sets smaller).
+
+<a id="semantic-matching"></a>
+
+## Semantic similarity threshold-based matching
+
+The basic idea behind "Semantic similarity threshold-based matching" is that a process that is "semantics aware" (in the loose sense, either by being cognisant about the graph structure, the logical structure, or a contextual textual knowledge such as an embedded Wikipedia article) enabled computing a score between the subject and object entity that to some degree reflects the "similarity" between the two entities. There are many examples of this:
+
+1. The (graph-)structure around the subject and object entities are projected into a common embedding space, and the similarity between the subject and object entities are expressed as cosine similarity between the two embeddings.
+1. The jaccard similarity between a set of properties of the subject and object entities is calculated.
+1. The Resnik score is calculated between the subject and object entities.
+
+**Important note on applicability of SSSOM for semantic similarity profiles**: SSSOM is not used for documenting semantic similarity profiles, i.e. cross-tables where some set of terms are compared with another set of terms and the semantic similarity is recorded as a score. SSSOM is used to document mappings, and only if a mapping decision is influenced by a semantic similarity based approach, especially in conjunction with as specific thresshold, SSSOM is applicable. For pure semantic similarity tables use [OAK Semantic Similarity](https://incatools.github.io/ontology-access-kit/datamodels/similarity/index.html).
+
+**Semantic vs lexical similarity?**: Semantic similarity is different from lexical similarity intuitively because the context (the graph structure, the background information) is taken into account and provides an (often crude) model of the actual entity, rather than of the word describing it. However, the distinctions can become a bit hazy. Imagine learning a graph embedding on a graph without edges, or a word embedding purely on a single label - there is definitely a grey zone where lexical similarity finishes and semantic similarity begins. In practice though, it should be mostly clear.
+
+## Level 1: Documenting semantic similarity matches
+
+The suggested metadata for semantic similarity threshold based matching approach is:
+
+- [semantic_similarity_measure](https://mapping-commons.github.io/sssom/semantic_similarity_measure/)
+- [semantic_similarity_score](https://mapping-commons.github.io/sssom/semantic_similarity_score/)
+- ((authors note: Maybe we need a [value for similarity threshold](https://github.com/mapping-commons/sssom/issues/296)?))
+
+<a id="mapping-review"></a>
+
+## Mapping review
+
+[semapv:MappingReview](https://w3id.org/semapv/vocab/MappingReview) is a process conducted by a (usually human) agent to determine the validity of a specific given mapping. It differs from [semapv:ManualMappingCuration](https://w3id.org/semapv/vocab/ManualMappingCuration) in that it does not involve looking for alternative mappings or indeed, necessarily determining if a mapping is the best possible mapping. It should be considered cheaper, less trustworthy evidence compared to [semapv:ManualMappingCuration](https://w3id.org/semapv/vocab/ManualMappingCuration).
+
+There are two kinds of mapping reviews in SSSOM:
+
+- Review as an independent justification: [semapv:MappingReview](https://w3id.org/semapv/vocab/MappingReview) is an independent process that determines the validity of a mapping.
+- Review _of_ an existing justification: Instead of evaluating an entire mapping, you can record the fact that someone has looked at a specific justification and deemed it acceptable. In this case, simply record the reviewers identify using the [reviewer_id](https://mapping-commons.github.io/sssom/reviewer_id/) or [reviewer_label](https://mapping-commons.github.io/sssom/reviewer_label/) fields.
+

--- a/src/docs/matching-tool-implementation-guide.md
+++ b/src/docs/matching-tool-implementation-guide.md
@@ -1,0 +1,75 @@
+# Matching Tools: Implementation Guide for SSSOM
+
+*Summary**: The goal of this document is to advice matching tool developers how to implement SSSOM-style matching justifications as part of their output. For example, if a mapping was determined (or is supported by) a lexical matching process, we can document that, alongside metadata that further describes the details about that process.
+
+As of 17.07.2023, this guide is a _work in progress_. If you are a tool developer interested to implement these recommendations, feel free to reach out on https://github.com/mapping-commons/sssom/issues for support and feel empowered to help us improve this guide!
+
+## Basics
+
+1. A (semantic) mapping in the sense of this guide is a tuple `<s, p, o, |j|>` that describes the correspondence of a subject `s` to an object `o` via a mapping predicate `p`. `|j|` is a non-empty set of mapping justifications that provide evidence towards the validity of the correspondence.
+1. As stated above, but re-stated for clarity: **every mapping can be associated with 1 or more justifications**.
+1. Carefully consider if a piece of metadata should be applied on [mapping](https://mapping-commons.github.io/sssom/Mapping/) or [mapping set](https://mapping-commons.github.io/sssom/MappingSet/) level. As a rule of thumb, if a piece of metadata applies to absolutely all mappings in the target set, then consider adding it as metadata to the mapping set, to safe space.
+1. Justifications in the sense of this guide comprise a *category* (documented in the [mapping_justification](https://mapping-commons.github.io/sssom/mapping_justification/) field), which is represented as a specific matching activity such as "lexical matching", "logical matching", "manual mapping curation", etc, a confidence value that represents the amount of confidence the justification contributes to the perceived truthfulness of a mapping, and additional metadata that provide additional provenance.
+1. The basic vocabulary for the justification category is the [Semantic Mapping Vocabulary](https://github.com/mapping-commons/semantic-mapping-vocabulary). Feel free to use the [issue tracker](https://github.com/mapping-commons/semantic-mapping-vocabulary/issues) to request new categories to be added. There is a fast turnaround.
+1. The goal of providing mapping justifications is to enable cross-purpose re-use of mappings, sharing of mappings and [mapping reconciliation](glossary.md). Mapping justifications make individual mapping decisions transparent.
+1. Adding justifications is always valueable, even if **not all detailed metadata is provided**.
+1. Many justifications are combinations of other justifications. For example, we may decide that a match is justified if (a) there is a lexical match and (b) the surrounding graph-structure is isomorphic or (c) the entities involved share the same properties. In this case, we should add individual justifications for each individual justification. The [confidence](https://mapping-commons.github.io/sssom/confidence/) value expresses how **confident the specific justification makes you feel about the truthfulness of the mapping**. If a joint probability is calculated from multiple justifications, add a separate justification for that, e.g. [semapv:CompositeMatching](https://w3id.org/semapv/vocab/CompositeMatching).
+1. In the SSSOM TSV formats, every row corresponds to a justification, not a mapping. So the same mapping with three justifications will result in three rows in the SSSOM TSV file.
+
+## Background
+
+Before reading on, please skim through the [technical documentation of SSSOM](index.md) to get a sense of what kind of properties exist, and read our primer on [mapping justifications](mapping-justifications.md) first, which explains how to design a number of frequently used mapping justifications.
+
+As the collection of justifications can impact the performance of he matching process (at least for huge matching tasks), it is adviseable that the process can be switched off by the CLI.
+
+For most matching processes, we first construct a candidate mapping set from a combination of sources, for example:
+
+1. Mappings provided by user as input to the matching process
+1. Lexical exact matching
+1. Lexical fuzzy matching (traditional and word embeddings)
+
+As a second step, we use often complex combinations of techniques to refine and expand the candidate mapping set:
+
+1. Structural matching (graph-based approaches etc)
+1. Semantic matching
+   1. Logical matching (for example by deconstructing complex terms into composites and then using logical reasoning).
+   1. Similarity based matching, including graph-embedding similarity (machine learning), old-school semantic similarity measures like Resnik or even Jaccard (over some part of the ontology/schema structure)
+
+As a rule of thumb, the more complex the rules by which a match is determined, the harder it is to provide a useful justification. To put it slighly differently: the more complex a justification, the less useful it is if the goal is to make matching decisions **transparent for human users**. A good example of this are decisions based on embedding (e.g. graph, node) similarity: while it is often useful to understand that a match has been determined by a threshold (e.g. >=0.9) of cosine similarity of a node embedding, it is less important to communicate exactly how the embedding space was constructed.
+
+This insight guides our implementation in two ways:
+
+1. We start by focusing on the "easy" cases with clear mapping justifications (like the lexical ones used to construct the _candidate mapping set_), and incrementally work our way up towards harder ones.
+1. We have a default justification for "complex" cases which we have not covered yet. This is necessary not only because it may be hard to construct complex justifications from within a matching tool, but also because SSSOM simply does not have a way to express the justification yet (in this case, request clarification on the [SSSOM issue tracker](https://github.com/mapping-commons/sssom/issues)).
+
+## Step-by-step guide for implementation
+
+This step by step guide is roughly according to our own thinking of what should be done first, second, and so on.
+
+1. Add an option to your matching tool to output legal SSSOM TSV (recommended format now), for example `--export-sssom` or similar.
+1. OPTIONAL: Add an option to your matching tool to accept legal SSSOM TSV as user input as an alternative to Alignment API (recommended format now).
+1. Always provide basic provenance in the SSSOM output:
+   - [mapping_tool](https://mapping-commons.github.io/sssom/mapping_tool/): The canonical reference to your tool, ideally a persistent identifier.
+   - [mapping_tool_version](https://mapping-commons.github.io/sssom/mapping_tool_version/): The version of the tool used to compute the mapping set.
+   - [mapping_set_id](https://mapping-commons.github.io/sssom/mapping_set_id/): A (often randomly generated) mapping set identifier.
+   - [mapping_date](https://mapping-commons.github.io/sssom/mapping_date/): The date the mapping was generated.
+   - OPTIONAL: if available, add [subject_source](https://mapping-commons.github.io/sssom/subject_source/), [object_source](https://mapping-commons.github.io/sssom/object_source/) and [subject_source_version](https://mapping-commons.github.io/sssom/subject_source_version/), [object_source_version](https://mapping-commons.github.io/sssom/object_source_version/).
+1. Document some basic entity metadata, this can help reading the mapping set:
+   - [subject_label](https://mapping-commons.github.io/sssom/subject_label/), [object_label](https://mapping-commons.github.io/sssom/object_label/): If available, add the label of the subject, and object id.
+1. Add basic justification support
+    1. Track lexical matching-based mapping decisions. A good chunk of candidate mappings will be computed by some form of lexical matching. See [here](mapping-justifications.md#lexical-matching) for details.
+    1. If something more complex than a simple lexical matching has happened, try to find an appropriate one in [SEMAPV](https://mapping-commons.github.io/semantic-mapping-vocabulary/). If none exists, or its too much work to create one, use as a fall-through:
+       - [semapv:CompositeMatching](https://w3id.org/semapv/vocab/CompositeMatching) in the case that the match was established through a combination of approaches, but you don't want to provide justifications for each individual one.
+       - [semapv:UnspecifiedMatching](https://w3id.org/semapv/vocab/UnspecifiedMatching) in the case you dont know why the match happened.
+    1. All justifications should come with a [confidence](https://mapping-commons.github.io/sssom/confidence/) value that expresses how **confident the specific justification makes you feel about the truthfulness of the mapping**.
+1. Track if a mapping was provided (as input) by a user. Ideally, if the input to the matching process is SSSOM, simply adopt all of the mapping justifications provided by the user. If the provided mapping has no metadata, add a suitable [mapping_provider](https://mapping-commons.github.io/sssom/mapping_provider/) value (e.g. `MYTOOL:USER`, to indicate  that the mapping was provided by the user).
+1. Add advanced justification support. Add all metadata explained in [mapping justifications](mapping-justifications.md). Where suitable fields or values are missing from the [SSSOM datamodel](https://mapping-commons.github.io/sssom/) or [SEMAPV](https://mapping-commons.github.io/semantic-mapping-vocabulary/), request them on the [SSSOM](https://github.com/mapping-commons/sssom/issues) or [SEMAPV issue tracker](https://github.com/mapping-commons/semantic-mapping-vocabulary/issues) respectively. There is likely a lot of interesting details to be added, so dont be shy to request/suggest!
+1. If you reject a user provided mapping, it makes sense to include that in a negative mapping set in SSSOM. You could provide [predicate_modifier](https://mapping-commons.github.io/sssom/predicate_modifier/)`= NOT` to ensure the file is not interpreted wrongly.
+1. HIGHLY OPTIONAL: In some few cases, it may be interesting to inform the user that not all mappings are 1:1. In this case, it could be advisable to use the `mapping_cardinality` field.
+1. OPTIONAL: If relevant you can add the [subject_type](https://mapping-commons.github.io/sssom/subject_type/) and [object_type](https://mapping-commons.github.io/sssom/object_type/) fields to your output, if known. This can be interesting in some cases with mixed content (being able to separate `owl:Class` related mappings from those about `owl:ObjectProperty`).
+1. You can always use the [comment](https://mapping-commons.github.io/sssom/comment/) or [other](https://mapping-commons.github.io/sssom/other/)* fields to deposit additional useful metadata that can later be turned into structured content.
+
+## Examples
+
+- [MGI Mouse-Human mappings](https://github.com/mapping-commons/mh_mapping_initiative/blob/master/mappings/mp_hp_mgi_all.sssom.tsv)
+- [SSSOM examples](https://github.com/mapping-commons/sssom/tree/master/examples/embedded)


### PR DESCRIPTION
Resolves #297 

- [X] `docs/` have been added/updated if necessary
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

This PR adds a provisional guide for matching tool developers that want to include SSSOM metadata into their pipelines.