### PR TITLE
Recommend that YAML keys be alphabetically sorted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Add issue_tracker_item and issue_tracker [model elements](https://github.com/mapping-commons/sssom/pull/259).
+- Add recommendation to sort the keys in the YAML metadata block.
 
 ## SSSOM version 0.13.0
 

--- a/src/docs/spec.md
+++ b/src/docs/spec.md
@@ -358,6 +358,8 @@ Note that the following prefixes are built-in and (1) MUST NOT be changed from t
 (The "canonical order" corresponds to the exact order of elements as seen in the specification.)
 This precludes spurious diffs in a git setting, which is an important concern for the continuous reviewing of mappings by curators and users. 
 
+**Ordering of keys in the YAML metadata block**. For the same reason (avoiding spurious diffs), the keys in the YAML metadata block SHOULD be sorted by case-sensitive alphabetical order. This recommendation applies whether the metadata block is embedded in the TSV file or kept in a separate file.
+
 Note that only metadata elements permissible in a global context (G, or L/G) can be used in the metadata-file.
 
 We recommend to use the following *filename conventions* for SSSOM metadatafiles:


### PR DESCRIPTION
This PR adds a recommendation that the keys in the YAML metadata block (in both "embedded" and "external" modes) SHOULD be sorted by case-sensitive alphabetical order.

There is no particular reason for recommending alphabetical order over any other type of order, beyond the fact that `sssom-py` is already using alphabetical order (probably because that is seemingly the default behaviour of the PyYAML's `safe_dump` method used by `sssom-py`). So we just take the order that is _de facto_ in use in the wild and make it the officially recommended order.

- [x] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally (no, documentation change only)
- [ ] tests have been added/updated (no, documentation change only)
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.