### PR TITLE
Recommend that YAML keys be sorted by "spec order".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Add issue_tracker_item and issue_tracker [model elements](https://github.com/mapping-commons/sssom/pull/259).
+- Add recommendation to sort the keys in the YAML metadata block.
 
 ## SSSOM version 0.13.0
 

--- a/src/docs/spec.md
+++ b/src/docs/spec.md
@@ -358,6 +358,8 @@ Note that the following prefixes are built-in and (1) MUST NOT be changed from t
 (The "canonical order" corresponds to the exact order of elements as seen in the specification.)
 This precludes spurious diffs in a git setting, which is an important concern for the continuous reviewing of mappings by curators and users. 
 
+**Canonical ordering of keys in the YAML metadata block**. For the same reason (avoiding spurious diffs), the keys in the YAML metadata block SHOULD be sorted in the same order as they are listed in the [MappingSet specification](https://mapping-commons.github.io/sssom/MappingSet/); keys in the `curie_map` dictionary SHOULD be sorted by alphabetical order. Those recommendations apply whether the metadata block is embedded in the TSV file or kept in a separate file.
+
 Note that only metadata elements permissible in a global context (G, or L/G) can be used in the metadata-file.
 
 We recommend to use the following *filename conventions* for SSSOM metadatafiles:


### PR DESCRIPTION
This PR adds a recommendation that

1) the keys in the YAML metadata block (in both "embedded" and “external” modes) SHOULD be sorted in the same order as the corresponding slots are listed in the definition of the [MappingSet class](https://mapping-commons.github.io/sssom/MappingSet/) in the SSSOM model;

2) the keys in the `curie_map` dictionary (i.e. the prefix names) SHOULD be sorted by alphabetical order.

This is an alternative PR to #319 (which proposed to sort the YAML metadata block by alphabetical order). “Spec order“ is not the current behaviour of `sssom-py`, but is preferred at least by @matentzn.

Of note, since `curie_map` is currently _not_ part of the model (and therefore not listed in the definition of `MappingSet`), the position of the `curie_map` key would be unspecified under the proposed recommendation. For what it’s worth, SSSOM-Java puts it at the top of the metadata block, before any other slot.

- [x] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally (no, irrelevant)
- [ ] tests have been added/updated (no, irrelevant)
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.