### PR TITLE
Ensure that github action workflow deploys custom docs

### DIFF
--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -72,5 +72,5 @@ jobs:
         mkdir docs
         touch docs/.nojekyll
         cp -r src/docs/* docs/
-        poetry run gen-doc -d docs src/sssom_schema/schema/sssom_schema.yaml
+        poetry run gen-doc -d docs src/sssom_schema/schema/sssom_schema.yaml --template-directory src/doc-templates
         poetry run mkdocs gh-deploy


### PR DESCRIPTION
Related to #332 #333 

- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

This PR ensures that the changes provided by @sujaypatil96 in #333 are also taken into account by the automatic SSSOM docs deploy system.