### PR TITLE
Update gendoc to copy subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(DOCDIR):
 	mkdir -p $@
 
 gendoc: $(DOCDIR)
-	cp $(SRC)/docs/*md $(DOCDIR) ; \
+	cp -rf $(SRC)/docs/* $(DOCDIR) ; \
 	$(RUN) gen-doc -d $(DOCDIR) $(SOURCE_SCHEMA_PATH) --template-directory $(TEMPLATE_DIR)
 
 testdoc: gendoc serve


### PR DESCRIPTION
Updating gendoc command to copy the whole docs directory into the docs dir, rather than just the top level. The current behaviour made a lot of pages inaccessible.
