### PR TITLE
Add new slot "mapping_status" (mapping lifecycle) to SSSOM core model

### DIFF
--- a/examples/schema/mapping_status.sssom.tsv
+++ b/examples/schema/mapping_status.sssom.tsv
@@ -1,0 +1,20 @@
+#curie_map:
+#  owl: http://www.w3.org/2002/07/owl#
+#  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+#  rdfs: http://www.w3.org/2000/01/rdf-schema#
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#  sssom: https://w3id.org/sssom/
+#  orcid: https://orcid.org/
+#  get: https://global-ecosystems.org/explore/
+#  alum8: http://www.neii.gov.au/def/voc/ACLUMP/australian-land-use-and-management-classification/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/mapping_status.sssom.tsv
+#license: "https://creativecommons.org/publicdomain/zero/1.0/"
+#creator_id: orcid:0000-0002-3884-3420
+#mapping_provider: "https://w3id.org/sssom/core_team"
+#comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
+subject_id	predicate_id	object_id	mapping_justification	author_id	mapping_date	status	comment
+alum8:Marsh-or-wetlandsaline	skos:exactMatch	get:groups/MFT1.3	semapv:ManualMappingCuration	orcid:0009-0001-6090-9959	2023-12-01	draft	
+alum8:Marsh-or-wetlandsaline	skos:exactMatch	get:groups/MFT1.3	semapv:ManualMappingCuration	orcid:0000-0002-2934-5497	2024-01-03	reviewed	Looks Ok but let's check with Piers
+alum8:Marsh-or-wetlandsaline	skos:exactMatch	get:groups/MFT1.3	semapv:ManualMappingCuration	orcid:0000-0002-2568-59457	2024-01-10	approved	Mapping has been approved by Pier and team.
+alum8:Marsh-or-wetlandsaline	skos:exactMatch	get:groups/MFT1.3	semapv:ManualMappingCuration	orcid:0000-0002-2934-5497	2024-01-13	published	

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -60,6 +60,21 @@ enums:
       "1:0": One-to-none mapping
       "0:1": None-to-one mapping
       "n:n": Many-to-many mapping
+  status_enum:
+    permissible_values:
+      draft:
+        description: "Indicates the mapping is in an early, unrefined form. This status is typically used for works in progress that are not yet ready for formal review or publication."
+      submitted:
+        description: "Represents the stage where the mapping has been submitted for review but has not yet been evaluated. This status is used after initial development and indicates readiness for external assessment."
+      reviewed:
+        description: "Denotes that the mapping has been reviewed by peers or evaluators, but it has not yet been formally accepted. This stage involves critical evaluation and may require revisions based on feedback."
+      accepted:
+        description: "Used when the mapping has been formally accepted for publication. This status indicates that it has passed the review phase and is awaiting publication."
+      published:
+        description: "Indicates that the mapping is officially published and publicly available. This is the final status and signifies that the work has completed all prior stages successfully."
+      withdrawn:
+        description: "Used if the mapping has been retracted or removed from consideration or publication. This can occur for various reasons, such as discovery of errors, author's decision, or other critical issues."
+
 
 types:
  EntityReference:
@@ -569,6 +584,18 @@ slots:
       by tool providing additional informative information.
     slot_uri: rdfs:comment
     range: string
+  mapping_status:
+    description: Specifies the current stage in the lifecycle of an ontology mapping. 
+      It represents various phases ranging from initial draft creation to final publication or withdrawal. 
+      It helps in tracking the progress and state of the mapping, providing clear indicators of its readiness, review status, and overall development phase.
+    range: status_enum
+    see_also:
+      - https://github.com/mapping-commons/sssom/issues/345
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/mapping_status.sssom.tsv
+    examples:
+      - value: draft
+        description: Draft status indicates that the mapping has been suggested, but not been reviewed or accepted by the mapping provider.
+
 classes:
   mapping set:
     description: Represents a set of mappings
@@ -635,6 +662,7 @@ classes:
     - mapping_cardinality
     - mapping_tool
     - mapping_tool_version
+    - mapping_status
     - mapping_date
     - publication_date
     - confidence


### PR DESCRIPTION
Resolves #345 

- [ ] `docs/` have been added/updated if necessary
- [X] `make test` has been run locally
- [ ] tests have been added/updated (not applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [X] provide a full, working and valid example in `examples/`
- [X] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [X] provide a link to a valid example in the `see_also` field of the linkml model

This is a draft PR adding a `mapping_status` metadata field to the SSSOM core model to describe the life cycle phase a specific mapping is in. Please use the issue for general discussions, and the PR only about specific suggestions.