### PR TITLE
Update documentation for entity reference to clarify CURIE/URI type

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -64,7 +64,10 @@ enums:
 types:
  EntityReference:
     typeof: uriorcurie
-    description: A reference to a mapped entity. This is represented internally as a string, and as a resource in RDF
+    description: |
+      A reference to an entity involved in the mapping.
+      In the JSON and TSV serialisation, an entity reference MUST be a CURIE.
+      In the RDF-based serialisations, an entity reference MUST be an IRI/URI.
     base: str
     uri: rdfs:Resource
 

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -66,10 +66,10 @@ types:
     typeof: uriorcurie
     description: |
       A reference to an entity involved in the mapping.
-      In the JSON and TSV serialisation, an entity reference MUST be a CURIE.
-      In the RDF-based serialisations, an entity reference MUST be an IRI/URI.
     base: str
     uri: rdfs:Resource
+    see_also:
+      - https://mapping-commons.github.io/sssom/spec/#tsv
 
 slots:
   mirror_from:


### PR DESCRIPTION
Resolves https://github.com/mapping-commons/sssom-py/issues/512

- [X] `docs/` have been added/updated if necessary

The documentation for "entity references" is largely confusing, and leading, in its current form, to the expectation that metadata fields types with these can be _either_ a CURIE _or_ a full URI.

This is not quite right: in the TSV serialistion, as well as JSON, we expect the values to be CURIE-strings. This PR documents this design decision, but, as @joeflack4 puts it rightfully, this has a bit of a "smell" to it. Not sure what the right thing is here, but this documentation here is certainly better than not having it.