### PR TITLE
Add min/max value constraints to score and confidence slots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add issue_tracker_item and issue_tracker [model elements](https://github.com/mapping-commons/sssom/pull/259).
 - Add recommendation to sort the keys in the YAML metadata block.
+- Double-typed slots explicitly constrained to the [0.0,1.0] range, as per their description.
 
 ## SSSOM version 0.13.0
 

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -449,6 +449,8 @@ slots:
     description: A score between 0 and 1 to denote the confidence or probability that
       the match is correct, where 1 denotes total confidence.
     range: double
+    minimum_value: 0.0
+    maximum_value: 1.0
   subject_match_field:
     description: A list of properties (term annotations on the subject) that was used
       for the match.
@@ -516,6 +518,8 @@ slots:
     description: A score between 0 and 1 to denote the semantic similarity, where
       1 denotes equivalence.
     range: double
+    minimum_value: 0.0
+    maximum_value: 1.0
   semantic_similarity_measure:
     description: The measure used for computing the the semantic similarity score.
       To make processing this field as unambiguous as possible, we recommend using 
@@ -528,6 +532,8 @@ slots:
     description: A score between 0 and 1 to denote the similarity, where
       1 denotes equivalence.
     range: double
+    minimum_value: 0.0
+    maximum_value: 1.0
   similarity_measure:
     description: The measure used for computing the the similarity score.
       To make processing this field as unambiguous as possible, we recommend using 


### PR DESCRIPTION
Resolves #372

- [ ] `docs/` have been added/updated if necessary (not applicable; the doc was already ahead of the model, this PR is about updating the model to align it with the doc)
- [x] `make test` has been run locally
- [ ] tests have been added/updated (not applicable)
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

The description of the `confidence`, `semantic_similarity_score`, and `similarity_score` slots says that those slots expect a value between 0 and 1, but the model does not enforce that. LinkML provides a way to formalise this kind of value constraints (which could then be automatically enforced by a runtime that is aware of those constraints), so we do exactly that here: we add `minimum_value` and `maximum_value` constraints to the aforementioned slots.