### PR TITLE
Add 'composed entity' value to the EntityType enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+- Add `composed entity` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next
 
-- Add `composed entity` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
+- Add `composed entity expression` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/examples/schema/composite-entities.sssom.tsv
+++ b/examples/schema/composite-entities.sssom.tsv
@@ -7,6 +7,6 @@
 #license: https://creativecommons.org/publicdomain/zero/1.0/
 #comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
 subject_id	predicate_id	object_id	mapping_justification	subject_type
-SCHEMA:0001/(disease:'MONDO:0005148',phenotype:'HP:0009124')	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	composed entity
-SCHEMA:0001/(disease:'MONDO:0005149',phenotype:'HP:0008551')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity
-SCHEMA:0001/(disease:'MONDO:0005150',phenotype:'HP:0000411')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity
+SCHEMA:0001/(disease:'MONDO:0005148',phenotype:'HP:0009124')	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	composed entity expression
+SCHEMA:0001/(disease:'MONDO:0005149',phenotype:'HP:0008551')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity expression
+SCHEMA:0001/(disease:'MONDO:0005150',phenotype:'HP:0000411')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity expression

--- a/examples/schema/composite-entities.sssom.tsv
+++ b/examples/schema/composite-entities.sssom.tsv
@@ -1,0 +1,12 @@
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MONDO: http://purl.obolibrary.org/obo/MONDO_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  SCHEMA: http://example.org/schema
+#mapping_set_id: https://w3id.org/sssom/commons/examples/composite-entities.sssom.tsv
+#license: https://creativecommons.org/publicdomain/zero/1.0/
+#comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
+subject_id	predicate_id	object_id	mapping_justification	subject_type
+SCHEMA:0001/(disease:'MONDO:0005148',phenotype:'HP:0009124')	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	composed entity
+SCHEMA:0001/(disease:'MONDO:0005149',phenotype:'HP:0008551')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity
+SCHEMA:0001/(disease:'MONDO:0005150',phenotype:'HP:0000411')	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	composed entity

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -45,7 +45,7 @@ enums:
         meaning: rdfs:Class
       rdfs literal:
         meaning: rdfs:Literal
-        description: This value indicate that the entity being mapped is not a semantic entity with a distinct identifier, but is instead represented entirely by its literal label. This value MUST NOT be used in the predicate_type slot.
+        description: This value indicates that the entity being mapped is not a semantic entity with a distinct identifier, but is instead represented entirely by its literal label. This value MUST NOT be used in the predicate_type slot.
         see_also:
         - https://mapping-commons.github.io/sssom/spec-model/#literal-mappings
         - https://github.com/mapping-commons/sssom/issues/234
@@ -54,6 +54,11 @@ enums:
         meaning: rdfs:Datatype
       rdf property:
         meaning: rdf:Property
+      composed entity:
+        description: This value indicates that the entity ID does not represent a single entity, but a composite involving several individual entities. This value MUST NOT be used in the predicate_type slot. This specifications does not prescribe how an ID representing a composite entity should be interpreted; this is left at the discretion of applications.
+        see_also:
+        - https://github.com/mapping-commons/sssom/issues/402
+        - https://github.com/mapping-commons/sssom/blob/master/examples/schema/composite-entities.sssom.tsv
         
   predicate_modifier_enum:
     permissible_values:

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -54,7 +54,7 @@ enums:
         meaning: rdfs:Datatype
       rdf property:
         meaning: rdf:Property
-      composed entity:
+      composed entity expression:
         description: This value indicates that the entity ID does not represent a single entity, but a composite involving several individual entities. This value MUST NOT be used in the predicate_type slot. This specifications does not prescribe how an ID representing a composite entity should be interpreted; this is left at the discretion of applications.
         see_also:
         - https://github.com/mapping-commons/sssom/issues/402


### PR DESCRIPTION
Resolves #402

- [ ] ~~`docs/` have been added/updated if necessary~~ (not needed; the new enum value is documented directly in the model’s `description` field)
- [x] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~ (nothing to test; the new value does not change anything to the expected behaviours)
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [x] provide a full, working and valid example in `examples/`
- [x] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [x] provide a link to a valid example in the `see_also` field of the linkml model
- [x] run SSSOM-Py test suite against the updated model


This PR adds a new value `composed entity` to the `EntityType` enumeration to indicate, as proposed in #402, that an ID is intended to represent a composed (aka “complex”, aka “post-coordinated”) entity that involves several individual entities.

