### PR TITLE
Add the `predicate_type` slot to Mapping and MappingSet classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next
 
 - Add `composed entity expression` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
+- Add `predicate_type` slot (previously defined but unused) to the `Mapping` and `MappingSet` classes ([issue](https://github.com/mapping-commons/sssom/issues/404)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/examples/schema/predicate-types.sssom.tsv
+++ b/examples/schema/predicate-types.sssom.tsv
@@ -1,0 +1,11 @@
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  ORGENT: https://example.org/entities/
+#  ORGPRO: https://example.org/properties/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/predicate-types.sssom.tsv
+#license: https://creativecommons.org/licenses/by/4.0/
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	predicate_type
+ORGENT:0001	alice	ORGPRO:example_annot_property	COMENT:0011	alpha	semapv:ManualMappingCuration	owl annotation property
+ORGENT:0002	bob	ORGPRO:example_object_property	COMENT:0012	beta	semapv:ManualMappingCuration	owl object property
+ORGENT:0004	daphne	ORGPRO:example_data_property	COMENT:0014	delta	semapv:ManualMappingCuration	owl data property
+ORGENT:0005	eve	ORGPRO:example_rdf_property	COMENT:0015	epsilon	semapv:ManualMappingCuration	rdf property

--- a/src/docs/spec-model.md
+++ b/src/docs/spec-model.md
@@ -56,7 +56,8 @@ For convenience, here is the current list of propagatable slots:
 * `subject_preprocessing`,
 * `subject_source`,
 * `subject_source_version`,
-* `subject_type`.
+* `subject_type`,
+* `predicate_type`.
 
 When a mapping set object has a value in one of its propagatable slots, this MUST be interpreted as if all mappings within the set had that same value in their corresponding slot. For example, if a set has the value _foo_ in its `mapping_tool` slot, all the mappings in that set MUST be treated as if they had the value _foo_ in their `mapping_tool` slot.
 

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -230,8 +230,13 @@ slots:
       - value: has cross-reference
         description: The label of the oboInOwl:hasDbXref property to represent cross-references.
   predicate_type:
-    description: The type of entity that is being mapped.
+    description: The type of the predicate used to map the subject and object entities.
     range: entity_type_enum
+    see_also:
+      - https://github.com/mapping-commons/sssom/issues/143
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/predicate-types.sssom.tsv
+    annotations:
+      propagated: true
     examples:
       - value: owl:AnnotationProperty
       - value: owl:ObjectProperty
@@ -721,6 +726,7 @@ classes:
     - object_type
     - object_source
     - object_source_version
+    - predicate_type
     - mapping_provider
     - mapping_tool
     - mapping_tool_version
@@ -761,6 +767,7 @@ classes:
     - object_type
     - object_source
     - object_source_version
+    - predicate_type
     - mapping_provider
     - mapping_source
     - mapping_cardinality


### PR DESCRIPTION
Resolves [#404]

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [x] provide a full, working and valid example in `examples/`
- [x] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [x] provide a link to a valid example in the `see_also` field of the linkml model
- [x] run SSSOM-Py test suite against the updated model

The `predicate_type` slot has been _defined_ but never _used_ in any classes. Presumably this is an oversight, so we add it here to the Mapping and MappingSet classes. We make it a “propagapable” slot, for consistency with the `subject_type` and `object_type` slots.