### PR TITLE
Add some missing justifications

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -277,7 +277,7 @@ slots:
   mapping_justification:
     description: A mapping justification is an action (or the written representation of that action) of showing a mapping to be right or reasonable.
     range: EntityReference
-    pattern: "^semapv:(MappingReview|ManualMappingCuration|LogicalReasoning|LexicalMatching|CompositeMatching|UnspecifiedMatching|SemanticSimilarityThresholdMatching|LexicalSimilarityThresholdMatching|MappingChaining)$"
+    pattern: "^semapv:(MappingReview|ManualMappingCuration|LogicalReasoning|LexicalMatching|CompositeMatching|UnspecifiedMatching|SemanticSimilarityThresholdMatching|LexicalSimilarityThresholdMatching|MappingChaining|MappingInversion|StructuralMatching|InstanceBasedMatching|BackgroundKnowledgeBasedMatching)$"
     required: true
     any_of:
       - equals_string: semapv:LexicalMatching
@@ -289,6 +289,10 @@ slots:
       - equals_string: semapv:MappingChaining
       - equals_string: semapv:MappingReview
       - equals_string: semapv:ManualMappingCuration
+      - equals_string: semapv:MappingInversion
+      - equals_string: semapv:StructuralMatching
+      - equals_string: semapv:InstanceBasedMatching
+      - equals_string: semapv:BackgroundKnowledgeBasedMatching
     examples:
       - value: semapv:LexicalMatching
       - value: semapv:ManualMappingCuration


### PR DESCRIPTION
There must be a better way to do this in LinkML by now!

- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [ ] provide a full, working and valid example in `examples/`
- [ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [ ] provide a link to a valid example in the `see_also` field of the linkml model
- [ ] run SSSOM-Py test suite against the updated model


This is adding a number of newer justifications to the validation rules of the schema. 

- [ ] Ask LinkML community what the state of the art way to do this is!
