### PR TITLE
Allow using `similarity_measure` at the set level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `composed entity expression` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
 - Add `predicate_type` slot (previously defined but unused) to the `Mapping` and `MappingSet` classes ([issue](https://github.com/mapping-commons/sssom/issues/404)).
+- Add `similarity_measure` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/411)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/src/docs/spec-model.md
+++ b/src/docs/spec-model.md
@@ -57,7 +57,8 @@ For convenience, here is the current list of propagatable slots:
 * `subject_source`,
 * `subject_source_version`,
 * `subject_type`,
-* `predicate_type`.
+* `predicate_type`,
+* `similarity_measure`.
 
 When a mapping set object has a value in one of its propagatable slots, this MUST be interpreted as if all mappings within the set had that same value in their corresponding slot. For example, if a set has the value _foo_ in its `mapping_tool` slot, all the mappings in that set MUST be treated as if they had the value _foo_ in their `mapping_tool` slot.
 

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -643,6 +643,8 @@ slots:
       To make processing this field as unambiguous as possible, we recommend using 
       wikidata CURIEs, but the type of this field is deliberately unspecified.
     range: string
+    annotations:
+      propagated: true
     examples:
       - value: https://www.wikidata.org/entity/Q865360
         description: the Wikidata IRI for the Jaccard index measure).
@@ -740,6 +742,7 @@ classes:
     - object_match_field
     - subject_preprocessing
     - object_preprocessing
+    - similarity_measure
     - see_also
     - issue_tracker
     - other

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -235,6 +235,7 @@ slots:
     see_also:
       - https://github.com/mapping-commons/sssom/issues/143
       - https://github.com/mapping-commons/sssom/blob/master/examples/schema/predicate-types.sssom.tsv
+    instantiates: sssom:Propagatable
     annotations:
       propagated: true
     examples:
@@ -643,6 +644,7 @@ slots:
       To make processing this field as unambiguous as possible, we recommend using 
       wikidata CURIEs, but the type of this field is deliberately unspecified.
     range: string
+    instantiates: sssom:Propagatable
     annotations:
       propagated: true
     examples:


### PR DESCRIPTION
Resolves [#411]

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- ~~[ ] provide a full, working and valid example in `examples/`~~
- ~~[ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model~~
- ~~[ ] provide a link to a valid example in the `see_also` field of the linkml model~~
- [x] run SSSOM-Py test suite against the updated model

This PR adds the `similarity_measure` slot to the `MappingSet` class, as a propagatable slot. It should be quite common that all `similarity_score` for all mappings in a set are determined using the same measure, so it makes sense to allow setting the measure once and for all at the set level, without having to repeat that information for all individual mappings.