### PR TITLE
Add links to semapv docs to sssom_schema.yaml mapping_justification slot

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -297,6 +297,9 @@ slots:
     examples:
       - value: semapv:LexicalMatching
       - value: semapv:ManualMappingCuration
+    see_also:
+      - https://mapping-commons.github.io/semantic-mapping-vocabulary/
+      - https://www.ebi.ac.uk/ols4/ontologies/semapv
   object_type:
     description: The type of entity that is being mapped.
     range: entity_type_enum


### PR DESCRIPTION
Fixes #417

- [X] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [ ] ~~provide a full, working and valid example in `examples/`~~
- [ ] ~~provide a link to the related GitHub issue in the `see_also` field of the linkml model~~
- [ ] ~~provide a link to a valid example in the `see_also` field of the linkml model~~
- [ ] ~~run SSSOM-Py test suite against the updated model~~


This PR simply adds links to the semap docs and OLS links to the mapping_justification slot. This will cause these links to show up on https://mapping-commons.github.io/sssom/mapping_justification/
