### PR TITLE
Add additional docs for subject and object match fields

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -539,7 +539,7 @@ slots:
       - value: 0.95
         description: A confidence score of 0.95, indicating 95% confidence.
   subject_match_field:
-    description:  >
+    description: >
       A list of properties, annotations or attributes related to the subject that was used
       to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
@@ -562,7 +562,7 @@ slots:
       A list of properties, annotations or attributes related to the object that was used
       to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
-      For additional information see the in 'See Also' section.
+      For additional information see the 'See Also' section.
     range: EntityReference
     multivalued: true
     instantiates: sssom:Propagatable
@@ -574,8 +574,8 @@ slots:
       - value: skos:prefLabel
         description: "The SKOS preferred label property (skos:prefLabel) was used to match the object."
     see_also:
-        - https://mapping-commons.github.io/sssom/mapping-justifications/#lexical-matching
-        - https://github.com/mapping-commons/sssom/issues/413
+      - https://mapping-commons.github.io/sssom/mapping-justifications/#lexical-matching
+      - https://github.com/mapping-commons/sssom/issues/413
   match_string:
     description: String that is shared by subj/obj. It is recommended to indicate the 
       fields for the match using the object and subject_match_field slots.

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -539,8 +539,11 @@ slots:
       - value: 0.95
         description: A confidence score of 0.95, indicating 95% confidence.
   subject_match_field:
-    description: A list of properties (term annotations on the subject) that was used
-      for the match.
+    description:  >
+      A list of properties, annotations or attributes related to the subject that was used
+      to establish the match. This property is recommended for use conjunction with 
+      mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
+      For additional information see below in 'See Also'.
     range: EntityReference
     multivalued: true
     instantiates: sssom:Propagatable
@@ -551,9 +554,15 @@ slots:
         description: "The RDFS label property (rdfs:label) was used to match the subject."
       - value: skos:prefLabel
         description: "The SKOS preferred label property (skos:prefLabel) was used to match the subject."
+    see_also:
+      - https://mapping-commons.github.io/sssom/mapping-justifications/#lexical-matching
+      - https://github.com/mapping-commons/sssom/issues/413
   object_match_field:
-    description: A list of properties (term annotations on the object) that was used
-      for the match.
+    description: >
+      A list of properties, annotations or attributes related to the object that was used
+      to establish the match. This property is recommended for use conjunction with 
+      mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
+      For additional information see below in 'See Also'.
     range: EntityReference
     multivalued: true
     instantiates: sssom:Propagatable
@@ -564,6 +573,9 @@ slots:
         description: "The RDFS label property (rdfs:label) was used to match the object."
       - value: skos:prefLabel
         description: "The SKOS preferred label property (skos:prefLabel) was used to match the object."
+    see_also:
+        - https://mapping-commons.github.io/sssom/mapping-justifications/#lexical-matching
+        - https://github.com/mapping-commons/sssom/issues/413
   match_string:
     description: String that is shared by subj/obj. It is recommended to indicate the 
       fields for the match using the object and subject_match_field slots.

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -541,9 +541,9 @@ slots:
   subject_match_field:
     description:  >
       A list of properties, annotations or attributes related to the subject that was used
-      to establish the match. This property is recommended for use conjunction with 
+      to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
-      For additional information see below in 'See Also'.
+      For additional information see the 'See Also' section.
     range: EntityReference
     multivalued: true
     instantiates: sssom:Propagatable
@@ -560,9 +560,9 @@ slots:
   object_match_field:
     description: >
       A list of properties, annotations or attributes related to the object that was used
-      to establish the match. This property is recommended for use conjunction with 
+      to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
-      For additional information see below in 'See Also'.
+      For additional information see the in 'See Also' section.
     range: EntityReference
     multivalued: true
     instantiates: sssom:Propagatable


### PR DESCRIPTION
Clarifying the intended use of subject and object match field in the main slot descriptions.

Fixes #413 

- [X] `docs/` have been added/updated if necessary
- [ ] ~~`make test` has been run locally~~
- [ ] ~~tests have been added/updated (if applicable)~~
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [ ] provide a full, working and valid example in `examples/`
- [X] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [ ] provide a link to a valid example in the `see_also` field of the linkml model
- [ ] run SSSOM-Py test suite against the updated model

Make it a bit clearer how subject and `object_match_field` are supposed to be used.

@nichtich does this work for you?
