### PR TITLE
Change type of `see_also` to `xsd:anyURI`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `composed entity expression` as a new value in the `EntityType` enumeration ([issue](https://github.com/mapping-commons/sssom/issues/402)).
 - Add `predicate_type` slot (previously defined but unused) to the `Mapping` and `MappingSet` classes ([issue](https://github.com/mapping-commons/sssom/issues/404)).
 - Add `similarity_measure` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/411)).
+- Change the type of the `see_also` slot to `xsd:anyURI` ([issue](https://github.com/mapping-commons/sssom/issues/422)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -689,8 +689,10 @@ slots:
     examples:
       - value: https://github.com/mapping-commons/mh_mapping_initiative/pull/41
         description: A URL pointing to the pull request that introduced the mapping.
-    range: string
+    range: uri
     multivalued: true
+    see_also:
+      - https://github.com/mapping-commons/sssom/issues/422
   other:
     description: "Pipe separated list of key value pairs for properties not part of
       the SSSOM spec. Can be used to encode additional provenance data. NOTE. This


### PR DESCRIPTION
Resolves [#422]

- [ ] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [ ] provide a full, working and valid example in `examples/`
- [x] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [ ] provide a link to a valid example in the `see_also` field of the linkml model
- [x] run SSSOM-Py test suite against the updated model

The `see_also` slot is explicitly described as expecting URL values, so there should not be any reason for it to be typed as `xsd:string`. We re-type it as a `xsd:anyURI` instead.