### PR TITLE
Add mapping_set_confidence slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `similarity_measure` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/411)).
 - Add `sssom_version` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/439)).
 - Change the type of the `see_also` slot to `xsd:anyURI` ([issue](https://github.com/mapping-commons/sssom/issues/422)).
+- Add `mappings_set_confidence` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/438)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/examples/schema/mapping_set_confidence.sssom.tsv
+++ b/examples/schema/mapping_set_confidence.sssom.tsv
@@ -1,0 +1,15 @@
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  orcid: https://orcid.org/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/curie_map.sssom.tsv
+#mapping_set_confidence: 0.8
+#license: "https://creativecommons.org/publicdomain/zero/1.0/"
+#creator_id:
+#  - orcid:0000-0002-7356-1779
+#mapping_provider: "https://w3id.org/sssom/core_team"
+#mapping_tool: AgreementMakerLight
+#comment: This is an example file for the SSSOM for illustration only. The mapping_set_confidence value expresses the confidence of the creator of the mapping into the agent that produced the mappings, i.e. AgreementMakerLight.
+subject_id	predicate_id	object_id	mapping_justification
+HP:0009124	skos:exactMatch	MP:0000003	semapv:LexicalMatching
+HP:0008551	skos:exactMatch	MP:0000018	semapv:LexicalMatching

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -116,6 +116,11 @@ slots:
   registry_confidence:
     description: This value is set by the registry that indexes the mapping set. It reflects the confidence the registry has in the correctness of the mappings in the mapping set.
     range: double
+    minimum_value: 0.0
+    maximum_value: 1.0
+    examples:
+      - value: 0.95
+        description: A confidence score of 0.95, indicating 95% confidence.
   last_updated:
     description: The date this reference was last updated.
     range: date
@@ -356,6 +361,21 @@ slots:
     slot_uri: dcterms:description
     examples:
       - value: "This mapping set was produced to integrate human and mouse phenotype data at the IMPC. It is primarily used for making mouse phenotypes searchable by human synonyms at https://mousephenotype.org/."
+  mapping_set_confidence:
+    description: Mapping-set level confidence is assigned by the creator of the mapping set, 
+      to indicate their overall confidence in the correctness of all mappings in the mapping set. 
+      Mapping set confidence is intended to be used in cases were the creator wants to express an
+      overall confidence into the agent that curated the individual mappings, for example a lexical
+      matching tool, or a group of students.
+    range: double
+    minimum_value: 0.0
+    maximum_value: 1.0
+    examples:
+      - value: 0.95
+        description: A confidence score of 0.95, indicating 95% confidence that the mappings in the mapping set are correct.
+    see_also:
+      - https://github.com/mapping-commons/sssom/issues/438
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/mapping_set_confidence.sssom.tsv
   creator_id:
     description: Identifies the persons or groups responsible for the creation of
       the mapping. The creator is the agent that put the mapping in its published form, 
@@ -759,6 +779,7 @@ classes:
     - mapping_set_source
     - mapping_set_title
     - mapping_set_description
+    - mapping_set_confidence
     - creator_id
     - creator_label
     - license


### PR DESCRIPTION
Resolves #438 

- [X] `docs/` have been added/updated if necessary
- [X] `make test` has been run locally
- [X] tests have been added/updated (if applicable)
- [X] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [X] provide a full, working and valid example in `examples/`
- [X] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [X] provide a link to a valid example in the `see_also` field of the linkml model
- [X] run SSSOM-Py test suite against the updated model

This PR is adding "mapping_set_confidence" slot to the mapping set class.
