### PR TITLE
Add `record_id` slot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `sssom_version` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/439)).
 - Change the type of the `see_also` slot to `xsd:anyURI` ([issue](https://github.com/mapping-commons/sssom/issues/422)).
 - Add `mappings_set_confidence` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/438)).
+- Add `record_id` slot to the `Mapping` class ([issue](https://github.com/mapping-commons/sssom/issues/359)).
 - TBD
 
 ## SSSOM version 1.0.0

--- a/examples/schema/record-ids.sssom.tsv
+++ b/examples/schema/record-ids.sssom.tsv
@@ -1,0 +1,10 @@
+# sssom_version: "1.1"
+# curie_map:
+#   HP: http://purl.obolibrary.org/obo/FBbt_
+#   MP: http://purl.obolibrary.org/obo/UBERON_
+#   RI: https://example.org/sets/record-id#
+# mapping_set_id: https://example.org/sets/record-id
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+record_id	subject_id	predicate_id	object_id	mapping_justification
+RI:0000001	HP:0009124	skos:exactMatch	MP:0000003	semapv:LexicalMatching
+RI:0000002	HP:0008551	skos:exactMatch	MP:0000018	semapv:LexicalMatching

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -779,6 +779,15 @@ slots:
     see_also:
       - https://github.com/mapping-commons/sssom/issues/328
       - https://github.com/mapping-commons/sssom/blob/master/examples/schema/extension-slots.sssom.tsv
+  record_id:
+    description: A unique identifier for a mapping record.
+    range: uriorcurie
+    instantiates: sssom:Versionable
+    annotations:
+      added_in: "1.1"
+    see_also:
+      - https://github.com/mapping-commons/sssom/issues/359
+      - https://github.com/mapping-commons/blob/master/examples/schema/record-ids.sssom.tsv
 classes:
   mapping set:
     description: Represents a set of mappings.
@@ -823,6 +832,7 @@ classes:
   mapping:
     description: Represents an individual mapping between a pair of entities.
     slots:
+    - record_id
     - subject_id
     - subject_label
     - subject_category
@@ -869,6 +879,17 @@ classes:
     - other
     - comment
     class_uri: owl:Axiom
+    unique_keys:
+      record_identifier:
+        description: >-
+          Each mapping within a mapping set MAY be identified by a unique, opaque record
+          identifier. This slot MUST be used consistently, in that either all mappings in
+          the set have a such a record identifier, or none of them have one. The
+          behaviour when a set contains both mappings with a record identifier and
+          mappings without a record identifier is unspecified. The behaviour when two
+          mappings have the same record identifier is unspecified.
+        unique_key_slots:
+          - record_id
     rules:
       - preconditions:
           slot_conditions:


### PR DESCRIPTION
Resolves [#359]

- ~~[ ] `docs/` have been added/updated if necessary~~ documentation is embedded in the LinkML schema.
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [x] provide a full, working and valid example in `examples/`
- [x] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [x] provide a link to a valid example in the `see_also` field of the linkml model
- [x] make sure any new slot is annotated with the appropriate `added_in` annotation
- [x] run SSSOM-Py test suite against the updated model

This PR adds a new slot to the `Mapping` class, `record_id`, intended to hold a unique identifier for a given mapping.

The slot is optional, so as not to break compatibility with existing SSSOM 1.0 sets. This also means that, while we can define the slot as a “unique key” for the Mapping class, we _cannot_ define it as the “identifier”, because in LinkML identifier slots are automatically mandatory.

The identifier is intended to be completely opaque. How to generate identifiers is left to the producers of SSSOM sets, and no meaning of any sort should be assigned to an identifier.