### PR TITLE
Change publication_date to be dcterms:issued

### DIFF
--- a/project/jsonld/sssom_schema.context.jsonld
+++ b/project/jsonld/sssom_schema.context.jsonld
@@ -247,7 +247,7 @@
       },
       "publication_date": {
          "@type": "xsd:date",
-         "@id": "dcterms:created"
+         "@id": "dcterms:issued"
       },
       "registry_confidence": {
          "@type": "xsd:double",

--- a/project/jsonld/sssom_schema.jsonld
+++ b/project/jsonld/sssom_schema.jsonld
@@ -1643,9 +1643,9 @@
       "description": "The date the mapping was published. This is different from the date the mapping was asserted.",
       "from_schema": "https://w3id.org/sssom/schema/",
       "mappings": [
-        "http://purl.org/dc/terms/created"
+        "http://purl.org/dc/terms/issued"
       ],
-      "slot_uri": "http://purl.org/dc/terms/created",
+      "slot_uri": "http://purl.org/dc/terms/issued",
       "owner": "Mapping",
       "domain_of": [
         "MappingSet",

--- a/project/owl/sssom_schema.owl.ttl
+++ b/project/owl/sssom_schema.owl.ttl
@@ -671,7 +671,7 @@ dcterms:created a owl:ObjectProperty,
     rdfs:label "publication_date" ;
     rdfs:range linkml:Date ;
     skos:definition "The date the mapping was published. This is different from the date the mapping was asserted." ;
-    skos:exactMatch dcterms:created .
+    skos:exactMatch dcterms:issued .
 
 dcterms:creator a owl:ObjectProperty,
         linkml:SlotDefinition ;

--- a/src/sssom_schema/context/sssom_schema.context.jsonld
+++ b/src/sssom_schema/context/sssom_schema.context.jsonld
@@ -247,7 +247,7 @@
       },
       "publication_date": {
          "@type": "xsd:date",
-         "@id": "dcterms:created"
+         "@id": "dcterms:issued"
       },
       "registry_confidence": {
          "@type": "xsd:double",

--- a/src/sssom_schema/context/sssom_schema.jsonld
+++ b/src/sssom_schema/context/sssom_schema.jsonld
@@ -1643,9 +1643,9 @@
       "description": "The date the mapping was published. This is different from the date the mapping was asserted.",
       "from_schema": "https://w3id.org/sssom/schema/",
       "mappings": [
-        "http://purl.org/dc/terms/created"
+        "http://purl.org/dc/terms/issued"
       ],
-      "slot_uri": "http://purl.org/dc/terms/created",
+      "slot_uri": "http://purl.org/dc/terms/issued",
       "owner": "Mapping",
       "domain_of": [
         "MappingSet",

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -576,7 +576,7 @@ slots:
       propagated: true
   publication_date:
     description: The date the mapping was published. This is different from the date the mapping was asserted.
-    slot_uri: dcterms:created
+    slot_uri: dcterms:issued
     range: date
     examples:
       - value: 2021-01-01


### PR DESCRIPTION
Publication date in dcterms is not `created` but `issued`. See for instance <https://www.w3.org/TR/vocab-dcat-3/#Property:resource_release_date>