### PR TITLE
Assign a property to ALL enum values.

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -75,24 +75,12 @@ enums:
       Not: Negating the mapping predicate. The meaning of the triple becomes subject_id is not a predicate_id match to object_id.
   mapping_cardinality_enum:
     permissible_values:
-      "1:1":
-        meaning: sssom:Cardinality_1_1
-        description: One-to-one mapping
-      "1:n":
-        meaning: sssom:Cardinality_1_n
-        description: One-to-many mapping
-      "n:1":
-        meaning: sssom:Cardinality_n_1
-        description: Many-to-one mapping
-      "1:0":
-        meaning: sssom:Cardinality_1_0
-        description: One-to-none mapping
-      "0:1":
-        meaning: sssom:Cardinality_0_1
-        description: None-to-one mapping
-      "n:n":
-        meaning: sssom:Cardinality_n_n
-        description: Many-to-many mapping
+      "1:1": One-to-one mapping
+      "1:n": One-to-many mapping
+      "n:1": Many-to-one mapping
+      "1:0": One-to-none mapping
+      "0:1": None-to-one mapping
+      "n:n": Many-to-many mapping
 
 types:
  EntityReference:

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -27,8 +27,12 @@ default_range: string
 enums:
   sssom_version_enum:
     permissible_values:
-      "1.0": SSSOM specification version 1.0
-      "1.1": SSSOM specification version 1.1
+      "1.0":
+        meaning: sssom:version1.0
+        description: SSSOM specification version 1.0
+      "1.1":
+        meaning: sssom:version1.1
+        description: SSSOM specification version 1.1
   entity_type_enum:
     permissible_values:
       owl class:
@@ -59,6 +63,7 @@ enums:
       rdf property:
         meaning: rdf:Property
       composed entity expression:
+        meaning: sssom:ComposedEntityExpression
         description: This value indicates that the entity ID does not represent a single entity, but a composite involving several individual entities. This value MUST NOT be used in the predicate_type slot. This specifications does not prescribe how an ID representing a composite entity should be interpreted; this is left at the discretion of applications.
         see_also:
         - https://github.com/mapping-commons/sssom/issues/402
@@ -66,15 +71,28 @@ enums:
         
   predicate_modifier_enum:
     permissible_values:
+      meaning: sssom:NegatedPredicate
       Not: Negating the mapping predicate. The meaning of the triple becomes subject_id is not a predicate_id match to object_id.
   mapping_cardinality_enum:
     permissible_values:
-      "1:1": One-to-one mapping
-      "1:n": One-to-many mapping
-      "n:1": Many-to-one mapping
-      "1:0": One-to-none mapping
-      "0:1": None-to-one mapping
-      "n:n": Many-to-many mapping
+      "1:1":
+        meaning: sssom:Cardinality_1_1
+        description: One-to-one mapping
+      "1:n":
+        meaning: sssom:Cardinality_1_n
+        description: One-to-many mapping
+      "n:1":
+        meaning: sssom:Cardinality_n_1
+        description: Many-to-one mapping
+      "1:0":
+        meaning: sssom:Cardinality_1_0
+        description: One-to-none mapping
+      "0:1":
+        meaning: sssom:Cardinality_0_1
+        description: None-to-one mapping
+      "n:n":
+        meaning: sssom:Cardinality_n_n
+        description: Many-to-many mapping
 
 types:
  EntityReference:

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -71,7 +71,8 @@ enums:
         
   predicate_modifier_enum:
     permissible_values:
-      Not: Negating the mapping predicate. The meaning of the triple becomes subject_id is not a predicate_id match to object_id.
+      Not:
+        description: Negating the mapping predicate. The meaning of the triple becomes subject_id is not a predicate_id match to object_id.
         meaning: sssom:NegatedPredicate
   mapping_cardinality_enum:
     permissible_values:

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -71,8 +71,8 @@ enums:
         
   predicate_modifier_enum:
     permissible_values:
-      meaning: sssom:NegatedPredicate
       Not: Negating the mapping predicate. The meaning of the triple becomes subject_id is not a predicate_id match to object_id.
+        meaning: sssom:NegatedPredicate
   mapping_cardinality_enum:
     permissible_values:
       "1:1": One-to-one mapping


### PR DESCRIPTION
Related to https://github.com/mapping-commons/sssom/discussions/454

- ~~[ ] `docs/` have been added/updated if necessary~~
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- ~~[ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~
- [x] run SSSOM-Py test suite against the updated model

This PR ensures that all enum values (_except_ for the `mapping_cardinality_enum`) throughout the LinkML model have a property assigned to them. This is important for RDF serialisation, so that all enum values are consistently rendered as resource identifiers, instead of having some values being rendered as resource identifiers and some values being rendered as string literals.

I normally agree with @nichtich ’s sentiment (expressed in #450) that we should as much as possible reuse existing properties from outside SSSOM (as we already do, for example, for most values of the `entity_type_enum`) and avoid creating SSSOM-specific properties in the `https://w3id.org/sssom/` namespace. However, for all the enum values concerned in this PR, I am not aware of pre-existing properties that would be suitable, so I did in fact create a bunch of SSSOM-specific properties. I am open to replacing some of them by more appropriate existing properties if someone can suggest some.

Also open to discussing the naming of those properties.

Of note, it would be nice if those properties could resolve to something meaningful to users. In particular, for the values in `sssom_version_enum`, I think most people would reasonably expect `https://w3id.org/sssom/version1.0` to resolve to a frozen version of the full specification as it was in the 1.0 release (and likewise for `https://w3id.org/sssom/version1.1` and any futur version). But this is an infrastructure issue that I consider out of scope for this PR.
