### PR TITLE
Add mapping_tool_id slot to model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Add `similarity_measure` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/411)).
 - Add `sssom_version` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/439)).
 - Change the type of the `see_also` slot to `xsd:anyURI` ([issue](https://github.com/mapping-commons/sssom/issues/422)).
-- Add `mappings_set_confidence` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/438)).
-- TBD
+- Add `mapping_set_confidence` slot to the `MappingSet` class ([issue](https://github.com/mapping-commons/sssom/issues/438)).
+- Add `mapping_tool_id` slot to the `Mapping` and `MappingSet` classes ([issue](https://github.com/mapping-commons/sssom/issues/449)).
 
 ## SSSOM version 1.0.0
 

--- a/examples/schema/mapping_tool_id.sssom.tsv
+++ b/examples/schema/mapping_tool_id.sssom.tsv
@@ -1,0 +1,14 @@
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  orcid: https://orcid.org/
+#  wikidata: https://www.wikidata.org/wiki/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/mapping_tool_id.sssom.tsv
+#license: "https://creativecommons.org/publicdomain/zero/1.0/"
+#creator_id: orcid:0000-0002-7356-1779
+#mapping_provider: "https://w3id.org/sssom/core_team"
+#issue_tracker: "https://github.com/mapping-commons/mh_mapping_initiative/issues"
+#comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
+subject_id	predicate_id	object_id	mapping_justification	mapping_tool_id
+HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	wikidata:Q58057366
+HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	wikidata:Q58057366

--- a/examples/schema/mapping_tool_id.sssom.tsv
+++ b/examples/schema/mapping_tool_id.sssom.tsv
@@ -5,7 +5,8 @@
 #  wikidata: https://www.wikidata.org/wiki/
 #mapping_set_id: https://w3id.org/sssom/commons/examples/mapping_tool_id.sssom.tsv
 #license: "https://creativecommons.org/publicdomain/zero/1.0/"
-#creator_id: orcid:0000-0002-7356-1779
+#creator_id:
+#  - orcid:0000-0002-7356-1779
 #mapping_provider: "https://w3id.org/sssom/core_team"
 #issue_tracker: "https://github.com/mapping-commons/mh_mapping_initiative/issues"
 #comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -565,6 +565,7 @@ slots:
     instantiates: sssom:Propagatable
     annotations:
       propagated: true
+      added_in: "1.1"
     examples:
       - value: wikidata:Q58057366
         description: A wikidata PURL identifying the AgreementMakerLight project.

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -562,7 +562,9 @@ slots:
     description: The ID (entity reference) of the tool or algorithm that was used to generate the
       mapping.
     range: EntityReference
-    instantiates: sssom:Propagatable
+    instantiates:
+      - sssom:Propagatable
+      - sssom:Versionable
     annotations:
       propagated: true
       added_in: "1.1"

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -548,6 +548,7 @@ slots:
   mapping_tool:
     description: A reference to the tool or algorithm that was used to generate the
       mapping. Should be a URL pointing to more info about it, but can be free text.
+      Consider using the mapping_tool_id slot for a more standardised reference.
     range: string
     instantiates: sssom:Propagatable
     annotations:
@@ -557,6 +558,19 @@ slots:
         description: A URL pointing to the AgreementMakerLight project.
       - value: AgreementMakerLight
         description: A string (name) denoting the AgreementMakerLight project.
+  mapping_tool_id:
+    description: The ID (entity reference) of the tool or algorithm that was used to generate the
+      mapping.
+    range: EntityReference
+    instantiates: sssom:Propagatable
+    annotations:
+      propagated: true
+    examples:
+      - value: wikidata:Q58057366
+        description: A wikidata PURL identifying the AgreementMakerLight project.
+    see_also:
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/mapping_tool_id.sssom.tsv
+      - https://github.com/mapping-commons/sssom/issues/449
   mapping_tool_version:
     description: Version string that denotes the version of the mapping tool used.
     range: string
@@ -807,6 +821,7 @@ classes:
     - predicate_type
     - mapping_provider
     - mapping_tool
+    - mapping_tool_id
     - mapping_tool_version
     - mapping_date
     - publication_date
@@ -851,6 +866,7 @@ classes:
     - mapping_source
     - mapping_cardinality
     - mapping_tool
+    - mapping_tool_id
     - mapping_tool_version
     - mapping_date
     - publication_date


### PR DESCRIPTION
Resolves #449 

- [X] `docs/` have been added/updated if necessary
- [X] `make test` has been run locally
- [X] tests have been added/updated (if applicable)
- [X] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [X] provide a full, working and valid example in `examples/`
- [X] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [X] provide a link to a valid example in the `see_also` field of the linkml model
- [X] make sure any new slot is annotated with the appropriate `added_in` annotation
- [X] run SSSOM-Py test suite against the updated model


This PR is adding mapping_tool_id as an entity reference to the SSSOM model. I have also included a note that if possible, this slot should be preferred over the less formal `mapping_tool` slot.

cc @nichtich @gouttegd  
