### PR TITLE
Make curation_rule_* slots propagatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add `mapping_tool_id` slot to the `Mapping` and `MappingSet` classes ([issue](https://github.com/mapping-commons/sssom/issues/449)).
 - Add `record_id` slot to the `Mapping` class ([issue](https://github.com/mapping-commons/sssom/issues/359)).
 - Change all URI-typed slots to clarify that they expect _non-relative_ URIs as values ([issue](https://github.com/mapping-commons/sssom/issues/448)).
+- `curation_rule` and `curation_rule_text` are made propagatable ([issue](https://github.com/mapping-commons/sssom/issues/464)).
 
 ## SSSOM version 1.0.0
 

--- a/examples/schema/curation_rule-propagated.sssom.tsv
+++ b/examples/schema/curation_rule-propagated.sssom.tsv
@@ -1,0 +1,16 @@
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  orcid: https://orcid.org/
+#  DISEASE_MAPPING_COMMONS_RULES: https://w3id.org/sssom/commons/disease/curation-rules/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/curation_rule.sssom.tsv
+#mapping_set_description: "This example illustrates how to express that all mapppings in a mapping set have been curated according to a specific curation rule"
+#license: "https://creativecommons.org/publicdomain/zero/1.0/"
+#creator_id: orcid:0000-0002-7356-1779
+#mapping_provider: "https://w3id.org/sssom/core_team"
+#curation_rule: DISEASE_MAPPING_COMMONS_RULES:MPR2
+#comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
+subject_id	predicate_id	object_id	mapping_justification
+HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR2
+HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR3
+HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR3

--- a/examples/schema/curation_rule-propagated.sssom.tsv
+++ b/examples/schema/curation_rule-propagated.sssom.tsv
@@ -10,9 +10,9 @@
 #mapping_provider: "https://w3id.org/sssom/core_team"
 #curation_rule:
 #  - DISEASE_MAPPING_COMMONS_RULES:MPR2
-
 #comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
 subject_id	predicate_id	object_id	mapping_justification
 HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration
 HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration
 HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration
+

--- a/examples/schema/curation_rule-propagated.sssom.tsv
+++ b/examples/schema/curation_rule-propagated.sssom.tsv
@@ -4,13 +4,14 @@
 #  orcid: https://orcid.org/
 #  DISEASE_MAPPING_COMMONS_RULES: https://w3id.org/sssom/commons/disease/curation-rules/
 #mapping_set_id: https://w3id.org/sssom/commons/examples/curation_rule.sssom.tsv
-#mapping_set_description: "This example illustrates how to express that all mapppings in a mapping set have been curated according to a specific curation rule"
+#mapping_set_description: "This example illustrates how to express that all mappings in a mapping set have been curated according to a specific curation rule"
 #license: "https://creativecommons.org/publicdomain/zero/1.0/"
 #creator_id: orcid:0000-0002-7356-1779
 #mapping_provider: "https://w3id.org/sssom/core_team"
-#curation_rule: DISEASE_MAPPING_COMMONS_RULES:MPR2
+#curation_rule:
+#  DISEASE_MAPPING_COMMONS_RULES:MPR2
 #comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
 subject_id	predicate_id	object_id	mapping_justification
-HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR2
-HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR3
-HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration	DISEASE_MAPPING_COMMONS_RULES:MPR3
+HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration
+HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration
+HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration

--- a/examples/schema/curation_rule-propagated.sssom.tsv
+++ b/examples/schema/curation_rule-propagated.sssom.tsv
@@ -9,7 +9,8 @@
 #creator_id: orcid:0000-0002-7356-1779
 #mapping_provider: "https://w3id.org/sssom/core_team"
 #curation_rule:
-#  DISEASE_MAPPING_COMMONS_RULES:MPR2
+#  - DISEASE_MAPPING_COMMONS_RULES:MPR2
+
 #comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
 subject_id	predicate_id	object_id	mapping_justification
 HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration

--- a/examples/schema/curation_rule-propagated.sssom.tsv
+++ b/examples/schema/curation_rule-propagated.sssom.tsv
@@ -15,4 +15,3 @@ subject_id	predicate_id	object_id	mapping_justification
 HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration
 HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration
 HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration
-

--- a/examples/schema/curation_rule_text-propagated.sssom.tsv
+++ b/examples/schema/curation_rule_text-propagated.sssom.tsv
@@ -1,0 +1,16 @@
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  orcid: https://orcid.org/
+#mapping_set_id: https://w3id.org/sssom/commons/examples/curation_rule.sssom.tsv
+#mapping_set_description: "This example illustrates how to express that all mappings in a mapping set have been curated according to a specific curation rule"
+#license: "https://creativecommons.org/publicdomain/zero/1.0/"
+#creator_id: orcid:0000-0002-7356-1779
+#mapping_provider: "https://w3id.org/sssom/core_team"
+#curation_rule_text:
+#  - Human and mouse phenotypes that inhere in homologous structures and exhibit the same phenotypic quality are considered exact matches.
+#comment: This is an example file for the SSSOM for illustration only. Its contents are entirely fabricated.
+subject_id	predicate_id	object_id	mapping_justification
+HP:0009124	skos:exactMatch	MP:0000003	semapv:ManualMappingCuration
+HP:0008551	skos:exactMatch	MP:0000018	semapv:ManualMappingCuration
+HP:0000411	skos:exactMatch	MP:0000021	semapv:ManualMappingCuration

--- a/src/doc-templates/index.md.jinja2
+++ b/src/doc-templates/index.md.jinja2
@@ -50,7 +50,7 @@ See [here](https://github.com/mapping-commons/sssom/tree/master/examples/schema)
 | Column/Field       | Description                                             | Required    |
 |--------------------|---------------------------------------------------------|-------------|
 {%- for slot in c.slots %}
-{%- set slot_info = schemaview.get_slot(slot) %}
+{%- set slot_info = schemaview.induced_slot(slot, c.name) %}
 | **{{ gen.link(slot) }}**     | {{ slot_info.description | default("No description") }} | {% if slot_info.required | default(false) %}Required{% elif slot_info.recommended | default(false) %}Recommended{% else %}Optional{% endif %} |
 {%- endfor %}
 {%- endif %}
@@ -65,7 +65,7 @@ See [here](https://github.com/mapping-commons/sssom/tree/master/examples/schema)
 | Column/Field       | Description                                             | Required    |
 |--------------------|---------------------------------------------------------|-------------|
 {%- for slot in c.slots %}
-{%- set slot_info = schemaview.get_slot(slot) %}
+{%- set slot_info = schemaview.induced_slot(slot, c.name) %}
 | **{{ gen.link(slot) }}**     | {{ slot_info.description | default("No description") }} | {% if slot_info.required | default(false) %}Required{% elif slot_info.recommended | default(false) %}Recommended{% else %}Optional{% endif %} |
 {%- endfor %}
 {%- endif %}

--- a/src/docs/spec-model.md
+++ b/src/docs/spec-model.md
@@ -43,6 +43,8 @@ The latter are called “propagatable slots”. In the LinkML model, they are ma
 
 For convenience, here is the current list of propagatable slots:
 
+* `curation_rule`,
+* `curation_rule_text`,
 * `cardinality_scope`,
 * `mapping_date`,
 * `mapping_provider`,
@@ -59,9 +61,7 @@ For convenience, here is the current list of propagatable slots:
 * `subject_source_version`,
 * `subject_type`,
 * `predicate_type`,
-* `similarity_measure`,
-* `curation_rule`,
-* `curation_rule_text`.
+* `similarity_measure`.
 
 When a mapping set object has a value in one of its propagatable slots, this MUST be interpreted as if all mappings within the set had that same value in their corresponding slot. For example, if a set has the value _foo_ in its `mapping_tool` slot, all the mappings in that set MUST be treated as if they had the value _foo_ in their `mapping_tool` slot.
 

--- a/src/docs/spec-model.md
+++ b/src/docs/spec-model.md
@@ -58,7 +58,9 @@ For convenience, here is the current list of propagatable slots:
 * `subject_source_version`,
 * `subject_type`,
 * `predicate_type`,
-* `similarity_measure`.
+* `similarity_measure`,
+* `curation_rule`,
+* `curation_rule_text`.
 
 When a mapping set object has a value in one of its propagatable slots, this MUST be interpreted as if all mappings within the set had that same value in their corresponding slot. For example, if a set has the value _foo_ in its `mapping_tool` slot, all the mappings in that set MUST be treated as if they had the value _foo_ in their `mapping_tool` slot.
 
@@ -237,3 +239,4 @@ Not all changes can be annotated thusly in the LinkML model, though. For changes
 * The value `composed entity expression` has been added to the `EntityType` enumeration.
 * The type of the `see_also` slot has been changed to `sssom:NonRelativeURI`. When parsing a SSSOM 1.0 set, implementations SHOULD accept arbitrary string values in that slot.
 * All slots that were typed as `xsd:anyURI` have been re-typed as `sssom:NonRelativeURI`. When parsing a SSSOM 1.0 set, implementations SHOULD accept relative URI values in those slots.
+* The `curation_rule` and `curation_rule_text` slots which previously only existed on the `Mapping` class, have been added to the `MappingSet` class. Both slots have now been typed [propagatable](#propagation-of-mapping-set-slots).

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -898,6 +898,8 @@ classes:
     - subject_preprocessing
     - object_preprocessing
     - similarity_measure
+    - curation_rule
+    - curation_rule_text
     - see_also
     - issue_tracker
     - other

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -721,6 +721,9 @@ slots:
       rule is captured as a resource rather than a string, which enables higher levels of transparency and sharing across mapping sets.
       The URI representation of the curation rule is expected to be a resolvable identifier which provides details about the nature of the curation rule.
     range: EntityReference
+    instantiates: sssom:Propagatable
+    annotations:
+      propagated: true
     multivalued: true
     examples:
       - value: DISEASE_MAPPING_COMMONS_RULES:MPR2
@@ -733,9 +736,12 @@ slots:
     description: A curation rule is a (potentially) complex condition executed by an agent that led to the establishment of a mapping. 
       Curation rules often involve complex domain-specific considerations, which are hard to capture in an automated fashion. The curation
       rule should be captured as a resource (entity reference) rather than a string (see curation_rule element), which enables higher levels of transparency and sharing across mapping sets.
-      The textual representation of curation rule is intended to be used in cases where (1) the creation of a resource is not practical from the
-      perspective of the mapping_provider and (2) as an additional piece of metadata to augment the curation_rule element with a human readable text.
+      The textual representation of curation rule is intended to be used in cases where the creation of a resource is not practical from the
+      perspective of the mapping_provider.
     range: string
+    instantiates: sssom:Propagatable
+    annotations:
+      propagated: true
     multivalued: true
     examples:
       - value: "The two phenotypes inhere in homologous structures and exhibit the same phenotypic quality."

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -783,6 +783,7 @@ slots:
       - https://github.com/mapping-commons/sssom/issues/166
       - https://github.com/mapping-commons/sssom/pull/258
       - https://github.com/mapping-commons/sssom/blob/master/examples/schema/curation_rule_text.sssom.tsv
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/curation_rule_text-propagated.sssom.tsv
   similarity_score:
     description: A score between 0 and 1 to denote the similarity between two entities, where
       1 denotes equivalence, and 0 denotes disjointness. The score is meant to be used in conjunction 

--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -764,6 +764,7 @@ slots:
       - https://github.com/mapping-commons/sssom/issues/166
       - https://github.com/mapping-commons/sssom/pull/258
       - https://github.com/mapping-commons/sssom/blob/master/examples/schema/curation_rule.sssom.tsv
+      - https://github.com/mapping-commons/sssom/blob/master/examples/schema/curation_rule-propagated.sssom.tsv
   curation_rule_text:
     description: A curation rule is a (potentially) complex condition executed by an agent that led to the establishment of a mapping. 
       Curation rules often involve complex domain-specific considerations, which are hard to capture in an automated fashion. The curation


### PR DESCRIPTION
- Make curation_rule_* slots propagatable 
- Remove a confusing part of the curation rule description.

Resolves #464 

- [X] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- [ ] ~tests have been added/updated (if applicable)~
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [x] provide a full, working and valid example in `examples/`
- [x] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [x] provide a link to a valid example in the `see_also` field of the linkml model
- [ ] make sure any new slot is annotated with the appropriate `added_in` annotation
- [ ] run SSSOM-Py test suite against the updated model