### PR TITLE
Fix chomping of description blocks for subject|object_match_field.

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -646,7 +646,7 @@ slots:
       - value: 0.95
         description: A confidence score of 0.95, indicating 95% confidence.
   subject_match_field:
-    description: >
+    description: >-
       A list of properties, annotations or attributes related to the subject that was used
       to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 
@@ -665,7 +665,7 @@ slots:
       - https://mapping-commons.github.io/sssom/mapping-justifications/#lexical-matching
       - https://github.com/mapping-commons/sssom/issues/413
   object_match_field:
-    description: >
+    description: >-
       A list of properties, annotations or attributes related to the object that was used
       to establish the match. This property is recommended for use in conjunction with 
       mapping justifications related to lexical matching, such as `semapv:LexicalMatching`. 


### PR DESCRIPTION
The description of the `subject_match_field` slot is written as a folded scalar block (`> ...`) with no explicit chomping indicator. As a result, the last newline character is interpreted as being part of the description.

This in turn messes with the formatting of the slot table on SSSOM's index page, because the row for the `subject_match_field` slot is spread over two lines (since the description cell contains a newline character):

```
| subject_match_field | description...
entity reference | rdfs:label |
```

instead of the expected:

```
| subject_match_field | description... | entity reference | rdfs:label |
```

This PR adds an explicit chomping indicator (`>-`) to prevent the terminating newline character from being taken as part of the scalar value.

Likewise for `object_match_field`.
