### PR TITLE
Annotate class-specific usage of slot with `added_in`.

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -901,6 +901,18 @@ classes:
     slot_usage:
       license:
         required: true
+      similarity_measure:
+        instantiates: sssom:Versionable
+        annotations:
+          added_in: "1.1"
+      curation_rule:
+        instantiates: sssom:Versionable
+        annotations:
+          added_in: "1.1"
+      curation_rule_text:
+        instantiates: sssom:Versionable
+        annotations:
+          added_in: "1.1"
     slots:
     - sssom_version
     - curie_map


### PR DESCRIPTION
- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- ~~[ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~ Already covered by previous changes

The `added_in` annotation is used to indicate that a slot has been introduced in a specific version of the specification. For now, that annotation is only used in the model-wide definition of slots, which means it can only indicate when a brand new slot has been introduced – it can not be used to indicate that a pre-existing slot has been added to a class in which it was not used before.

For example, the `similarity_measure` slot has existed since before 1.0, but has been only been added to the `MappingSet` class for version 1.1. Currently that information is _not_ contained in the model, implementers need to check the [Model changes across versions](https://mapping-commons.github.io/sssom/spec-model/#model-changes-across-versions) section of the spec to be aware of that.

Likewise for `curation_rule` and `curation_rule_text`, which have just been added to the `MappingSet` class.

In this PR, we make use of LinkML's `slot_usage` mechanism to add the `added_in` annotation not only to the general (model-wide) definition of a slot, but also to the specific instance of a slot within a class.

This allows to encode, directly into the model, that the use of `similarity_measure`, `curation_rule`, and `curation_rule_text` at the level of the `MappingSet` class is only possible starting from version 1.1.

(This really should have been done directly in the PRs that added those slots to the `MappingSet` class – #412 and #472 –, but at the time I had not realized that it was possible to use `slot_usage` to add annotations to a slot only within the context of a particular class.)