### PR TITLE
Move definition of propagation/condensation outside of SSSOM/TSV.

### DIFF
--- a/src/docs/spec-formats-tsv.md
+++ b/src/docs/spec-formats-tsv.md
@@ -111,27 +111,6 @@ As stated in the description of the model ([Identifiers section](spec-model.md#i
 A SSSOM/TSV writer SHOULD refuse to serialise a mapping set that contains IRIs that cannot be contracted into CURIEs because there is no suitable prefix declaration in its CURIE map. The use of a custom, ad-hoc logic to infer a possible prefix name where none has been provided (e.g., “if the IRI ends with a `ZZZ_NNNNNNN` pattern, turn it into a `ZZZ:NNNNNNN` CURIE”) is strongly discouraged.
 
 
-## Propagatable slots
-
-As [explained in another section](spec-model.md#propagation-of-mapping-set-slots), some slots in the `MappingSet` class are intended, not to describe the mapping set itself, but to store values that are shared by all mappings in the set. These slots are called the “propagatable slots”, because their values should be “propagated” from the mapping set down to the individual mappings.
-
-### Propagation
-
-“Propagation” is the operation of assigning to individual mappings in a set the values from the propagatable slots of the set. That operation SHOULD be performed by a SSSOM/TSV parser before passing the parsed objects to the application code.
-
-For any given propagatable slot, propagation is only allowed if none of the individual mappings already have their own value in that slot. If any mapping (even only one mapping) has a value in that slot, then the slot MUST be considered as non-propagatable. Otherwise, a propagating SSSOM/TSV parser MUST (1) copy over the value of the propagatable slot on the `MappingSet` object to the corresponding slot of every individual `Mapping` objects, and (2) remove the propagated value from the `MappingSet` object.
-
-Implementations that support propagation MUST also support condensation.
-
-### Condensation
-
-“Condensation” is the opposite of “propagation”. It is the operation of assigning common values to the propagatable slots of the set, based on the values of these slots on individual mappings. That operation SHOULD be performed by a SSSOM/TSV writer prior to writing a set into a SSSOM/TSV file, but that behaviour, if available, MUST be deactivatable.
-
-For any given propagatable slot, condensation is only allowed if (1) all mappings in the set have the same value, and (2) the mapping set does not already have a value in the slot, unless that value happens to be the same as the value in all mappings. If those two conditions are met, then a condensating SSSOM/TSV writer MUST (1) set the value of the slot on the `MappingSet` object to the common value of the slot in all mappings, and (2) remove the condensed value from the individual `Mapping` object.
-
-Implementations that support condensation MUST also support propagation.
-
-
 ## Non-standard slots
 
 If an implementation does not support [non-standard slots](spec-model.md#non-standard-slots), then:

--- a/src/docs/spec-model.md
+++ b/src/docs/spec-model.md
@@ -32,7 +32,7 @@ Whenever the CURIE syntax is used in a mapping set (whether this is by choice of
 By exception, prefix names listed in the table found in the [IRI prefixes](spec-intro.md#iri-prefixes) section are considered “built-in”. As such, they MAY be omitted from the `curie_map`. If they are not omitted, they MUST point to the same IRI prefixes as in the aforementioned table.
 
 
-## Propagation of mapping set slots
+## Propagatable slots
 
 As mentioned briefly above, there are two different types of slots in the `MappingSet` class:
 
@@ -68,6 +68,28 @@ When a mapping set object has a value in one of its propagatable slots, this MUS
 This mechanism is intended as a convenience, so that a slot which has the same value for all mappings in a set can be specified only once at the level of the set rather than for each individual mapping.
 
 Slots that are not in the above list (“non-propagatable slots”) describe the mapping set itself, not the mappings it contains, even if the slot also exists on the `Mapping` class. For example, the `creator_id` slot, when used in the `MappingSet` class, is intended to refer to the creators of the set, _not_ the creators of the individual mappings (which may be different, and which are listed in the `creator_id` slot of every mapping).
+
+### Propagation
+
+“Propagation” is the operation of assigning to individual mapping records in a set the values from the propagatable slots of the set.
+
+For any given propagatable slot, propagation is only allowed if none of the individual mapping records already have their own value in that slot. If any record (even only one record) has a value in that slot, then the slot MUST be considered as non-propagatable. Otherwise, to propagate the slot an implementation MUST (1) copy over the value of the propagatable slot on the mapping set to the corresponding slot of every individual mapping records, and (2) remove the propagated value from the mapping set.
+
+### Condensation
+
+“Condensation” is the opposite of “propagation”. It is the operation of assigning common values to the propagatable slots of the set, based on the values of these slots on individual mapping records.
+
+For any given propagatable slot, condensation is only allowed if (1) all mapping records in the set have the same value for that slot, and (2) the mapping set itself does not already have a value in the slot, unless that value happens to be the same as the value in all records. If those two conditions are met, then to condense the slot an implementation MUST (1) set the value of the slot on the mapping set to the common value of the slot in all mapping records, and (2) remove the condensed value from all the mapping records.
+
+### When to perform propagation and condensation
+
+Implementations SHOULD support propagation and condensation. The two features MUST NOT be dissociated; that is, an implementation that supports propagation MUST also support condensation, and the other way round.
+
+Unless specified otherwise in the specification for the [SSSOM serialisation formats](spec-formats.md), if an implementation supports propagation and condensation, then:
+
+* propagation SHOULD be performed by a SSSOM parser before passing the parsed objects to the application code;
+
+* condensation SHOULD be performed by a SSSOM writer prior to writing the set into a file, however that behaviour MUST be deactivatable.
 
 
 ## Allowed and common mapping predicates


### PR DESCRIPTION
Resolves [#486]

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- ~~[ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~

Propagation and condensation of "propagatable" slots is currently only defined in the specification for the SSSOM/TSV format. This is not appropriate as those operations are completely independent of the format – propagation and condensation are performed identically regardless of whether a mapping set is read/written from/to a SSSOM/TSV file, a SSSOM/JSON file, or a RDF file.

So in this PR, we move the definition of those operations to the general introduction (serialisation-independent) of the SSSOM model.

We do not change anything about how propagation and condensation are performed, and the associated requirements.