### PR TITLE
Update PyPI publish workflow for prereleases

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -27,8 +27,9 @@ jobs:
         pipx inject poetry poetry-dynamic-versioning
 
 
-    - name: Build sdist & wheel
-      run: poetry build
+    - name: Build source and wheel archives
+      run: |
+        poetry build
 
     - name: Store built distribution
       uses: actions/upload-artifact@v4.6.2

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -26,17 +26,6 @@ jobs:
         pipx install poetry
         pipx inject poetry poetry-dynamic-versioning
 
-    - name: Set version for pre-release (PEP 440 compliant)
-      if: github.event.release.prerelease == true
-      shell: bash
-      run: |
-        BASE_VERSION="$(poetry version -s | sed 's/+.*//')"  # strip any local part
-        DATE="$(date -u +%Y%m%d)"
-        RUN="${{ github.run_number }}"
-        SHA="$(git rev-parse --short HEAD)"
-        PRERELEASE_VERSION="${BASE_VERSION}.dev${DATE}${RUN}+g${SHA}"
-        echo "Setting version to ${PRERELEASE_VERSION}"
-        poetry version "${PRERELEASE_VERSION}"
 
     - name: Build sdist & wheel
       run: poetry build

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -3,8 +3,8 @@ name: Publish Python Package
 
 on:
   release:
-    # Trigger the workflow only for real releases but not for draft releases
-    types: [created]
+    # Run when a release is published or a prerelease is published (not on draft creation)
+    types: [published, prereleased]
 
 jobs:
   build:
@@ -26,9 +26,20 @@ jobs:
         pipx install poetry
         pipx inject poetry poetry-dynamic-versioning
 
-    - name: Build source and wheel archives
+    - name: Set version for pre-release (PEP 440 compliant)
+      if: github.event.release.prerelease == true
+      shell: bash
       run: |
-        poetry build
+        BASE_VERSION="$(poetry version -s | sed 's/+.*//')"  # strip any local part
+        DATE="$(date -u +%Y%m%d)"
+        RUN="${{ github.run_number }}"
+        SHA="$(git rev-parse --short HEAD)"
+        PRERELEASE_VERSION="${BASE_VERSION}.dev${DATE}${RUN}+g${SHA}"
+        echo "Setting version to ${PRERELEASE_VERSION}"
+        poetry version "${PRERELEASE_VERSION}"
+
+    - name: Build sdist & wheel
+      run: poetry build
 
     - name: Store built distribution
       uses: actions/upload-artifact@v4.6.2
@@ -45,7 +56,7 @@ jobs:
       name: pypi-release
       url: https://pypi.org/p/sssom-schema
     permissions:
-      id-token: write  # This permission is mandatory for trusted publishing.
+      id-token: write  # required for OIDC trusted publishing
     steps:
       - name: Download built distribution
         uses: actions/download-artifact@v4.3.0
@@ -54,7 +65,7 @@ jobs:
           path: dist
 
       - name: Publish package 📦 to PyPI
-        if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           verbose: true
+          skip-existing: true

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -26,7 +26,6 @@ jobs:
         pipx install poetry
         pipx inject poetry poetry-dynamic-versioning
 
-
     - name: Build source and wheel archives
       run: |
         poetry build
@@ -46,7 +45,7 @@ jobs:
       name: pypi-release
       url: https://pypi.org/p/sssom-schema
     permissions:
-      id-token: write  # required for OIDC trusted publishing
+      id-token: write  # This permission is mandatory for trusted publishing.
     steps:
       - name: Download built distribution
         uses: actions/download-artifact@v4.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add `curation_rule` and `curation_rule_text` to the `MappingSet` class and made propagatable ([issue](https://github.com/mapping-commons/sssom/issues/464)).
 - Add `cardinality_scope` slot ([issue](https://github.com/mapping-commons/sssom/issues/467)).
 - Add new value `0:0` to the `mapping_cardinality_enum` ([issue](https://github.com/mapping-commons/sssom/issues/477)).
+- Development snapshots of SSSOM schema can now be released using GitHubs pre-release feature ([issue](https://github.com/mapping-commons/sssom/issues/490))
 
 ## SSSOM version 1.0.0
 


### PR DESCRIPTION
Workflow now triggers on published and prereleased events, sets PEP 440-compliant version for prereleases, and adds 'skip-existing' to PyPI publish step. Improves handling of pre-release publishing and artifact management.

Resolves #490 

- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [X] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.
