### PR TITLE
Allow using TeX markup in documentation.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,10 +23,15 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.tilde
+  - pymdownx.arithmatex:
+      generic: true
   - admonition
   #- pymdownx.emoji:
   #    emoji_index: !!python/name:material.extensions.emoji.twemoji
   #    emoji_generator: !!python/name:material.extensions.emoji.to_svg
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 nav:
   - Home: index.md
   - Introduction: introduction.md

--- a/src/docs/javascripts/mathjax.js
+++ b/src/docs/javascripts/mathjax.js
@@ -1,0 +1,19 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache()
+  MathJax.typesetClear()
+  MathJax.texReset()
+  MathJax.typesetPromise()
+})


### PR DESCRIPTION
Resolves [#525]

- [ ] ~~`docs/` have been added/updated if necessary~~
- [x] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~
- [ ] ~~[CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~

This PR configure mkdocs to allow the use of the MathJax library for math rendering.

Not particularly fond of having to fetch a piece of Javascript from God knows where, but this is apparently the normal (at least, "normal in the world of Javascript") way of doing it [1].

closes #525

[1] https://squidfunk.github.io/mkdocs-material/reference/math/#configuration