### PR TITLE
[superceded] Define a standard SSSOM hashing function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add `review_date` slot ([issue](https://github.com/mapping-commons/sssom/issues/511))
 - Add `reviewer_agreement` slot ([issue](https://github.com/mapping-commons/sssom/issues/510))
 - Allow encoding pipe characters in multi-valued slots in SSSOM/TSV format ([issue](https://github.com/mapping-commons/sssom/issues/429)).
+- Specify a standard SSSOM hashing function ([issue](https://github.com/mapping-commons/sssom/issues/436)).
 
 ## SSSOM version 1.0.0
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,6 @@ nav:
       - Introduction: spec-intro.md
       - Data model:
           - Introduction: spec-model.md
-          - Applying Chaining Rules: chaining-rules.md
           - LinkML documentation: linkml-index.md
       - Serialisations:
           - Introduction: spec-formats.md
@@ -48,6 +47,10 @@ nav:
           - SSSOM/JSON serialisation: spec-formats-json.md
           - SSSOM/RDF serialisation: spec-formats-rdf.md
           - OWL/RDF serialisation: spec-formats-owl.md
+      - Support functions:
+          - Introduction: spec-support.md
+          - Hashing mapping records: spec-support-hashing.md
+          - Applying Chaining Rules: chaining-rules.md
   - Resources for contributors: contributing.md
   - Resources for users:
       - FAQ: faq.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
           - Matching tool implementation guide: matching-tool-implementation-guide.md
           - How to gradually enrich OMOP mappings with SSSOM: tutorials/omop-mappings.md
           - How to assess mapping confidence: confidence-model.md
+          - Identifying mapping records: record-identifiers.md
       - Reference:
           - Glossary: glossary.md
   - Related documentation: related-documentation.md

--- a/src/docs/record-identifiers.md
+++ b/src/docs/record-identifiers.md
@@ -139,7 +139,7 @@ bad idea
 
 An identifier can be automatically derived from the record by running the record
 through some kind of condensation (“hash”) function that returns a value
-calculcated in such a way that the probability that two different records could
+calculated in such a way that the probability that two different records could
 yield the same value can be considered negligible.
 
 The SSSOM specification defines [such a function](spec-support-hashing.md).

--- a/src/docs/record-identifiers.md
+++ b/src/docs/record-identifiers.md
@@ -1,0 +1,226 @@
+# Identifying mapping records
+
+Since version 1.1, the SSSOM specification allows to explicitly assign an
+identifier to every single mapping record within a given mapping set, through
+the [record_id](../record-id.md) slot.
+
+The specification is deliberately non-prescriptive about what record identifiers
+should look like or how they should be generated. The only constraints on the
+`record_id` slot are that:
+
+- the value must be a URI;
+- the URI must be representable in CURIE form in some serialisations (e.g. in
+  SSSOM/TSV);
+- either all records within a set have an identifier, or none have one;
+- each identifier should be unique within the set that contains it.
+
+Beyond those constraints, it is left to the creators of a SSSOM mapping set to
+decide whether and how to mint identifiers for their records. This page is
+intended to provide some non-normative guidance.
+
+## Uniqueness scope
+
+While the specification only mandates that record identifiers must be unique
+**within a set**, it is probably a good idea to use identifiers that are
+**globally** unique.
+
+An easy way to do that is to construct the identifiers on top of the
+`mapping_set_id` of the mapping set.
+
+For example, if you have the following set:
+
+```
+#curie_map:
+#  FOODON: http://purl.obolibrary.org/obo/FOODON_
+#  KF_FOOD: https://kewl-foodie.inc/food/
+#license: https://creativecommons.org/licenses/by/4.0/
+#mapping_set_id: https://w3id.org/sssom/tutorial/example1
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+KF_FOOD:F001	apple	skos:exactMatch	FOODON:00002473	apple (whole)	semapv:ManualMappingCuration
+KF_FOOD:F002	gala	skos:exactMatch	FOODON:00003348	Gala apple (whole)	semapv:ManualMappingCuration
+KF_FOOD:F003	pink	skos:exactMatch	FOODON:00004187	Pink apple (whole, raw)	semapv:ManualMappingCuration
+KF_FOOD:F004	braeburn	skos:broadMatch	FOODON:00002473	apple (whole)	semapv:ManualMappingCuration
+```
+
+then you could construct the following identifiers, all derived by appending a
+local part to the `mapping_set_id` URI:
+
+- `https://w3id.org/sssom/tutorial/example1#001`
+- `https://w3id.org/sssom/tutorial/example1#002`
+- `https://w3id.org/sssom/tutorial/example1#003`
+- `https://w3id.org/sssom/tutorial/example1#004`
+
+Assuming the `mapping_set_id` URI is globally unique (which it should be), then
+all record identifiers derived from it will necessarily be globally unique as
+well.
+
+The resulting set would then look as follows (keep in mind that record
+identifiers must be in CURIE form in the SSSOM/TSV format):
+
+```
+#curie_map:
+#  FOODON: http://purl.obolibrary.org/obo/FOODON_
+#  KF_FOOD: https://kewl-foodie.inc/food/
+#  example1: https://w3id.org/sssom/tutorial/example1#
+#license: https://creativecommons.org/licenses/by/4.0/
+#mapping_set_id: https://w3id.org/sssom/tutorial/example1
+record_id   subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+example1:001    KF_FOOD:F001	apple	skos:exactMatch	FOODON:00002473	apple (whole)	semapv:ManualMappingCuration
+example1:002    KF_FOOD:F002	gala	skos:exactMatch	FOODON:00003348	Gala apple (whole)	semapv:ManualMappingCuration
+example1:003    KF_FOOD:F003	pink	skos:exactMatch	FOODON:00004187	Pink apple (whole, raw)	semapv:ManualMappingCuration
+example1:004    KF_FOOD:F004	braeburn	skos:broadMatch	FOODON:00002473	apple (whole)	semapv:ManualMappingCuration
+```
+
+> Again, this is **guidance** only. There is _no obligation_ for record
+> identifiers to be derived from the `mapping_set_id`. It is simply a convenient
+> way to achieve global uniqueness, should it be desired.
+
+## Identifier generation methods
+
+Here are some of the ways by which the local part of identifiers can be
+generated.
+
+### Opaque identifiers
+
+#### Serially allocated numbers
+
+This is the method used in the example above. The local part of the identifier
+is a (typically fixed-width) number that is simply incremented whenever a new
+identifier is needed.
+
+This is arguably the simplest method, and one that is especially practical when
+creating/editing a mapping set using a generic, non-SSSOM-aware spreadsheet
+software. It requires keeping track of the last used number, but that should not
+be a big hurdle when editing a set in a spreadsheet software.
+
+#### Randomly allocated numbers
+
+The local part of the identifier can be made of numbers that are randomly picked
+rather than serially allocated. This dispenses of the need to keep track of the
+last used number.
+
+For this method to work, the random numbers must be picked (1) within a large
+enough space and (2) using an established and solidly implemented pseudo-random
+number generator (PRNG) software. In particular, they should _not_ be
+hand-picked by a human editor (or a LLM). Humans (and the LLMs that try to mimic
+them) are notoriously bad at producing random numbers.
+
+Of note, this method can easily produce **globally unique** identifiers on its
+own if the space in which the random numbers are picked is large enough.
+Typically, using 128-bit numbers (and assuming a proper PRNG), the probability
+of two random identifiers colliding is sufficiently low that for all purposes
+the identifiers can be considered globally unique.
+
+### Non-opaque identifiers
+
+#### Manually crafted non-opaque strings
+
+A human editor could mint an identifier that meaningfully represents some “key”
+characteristics of the mapping record. For example, the first record in the
+example mapping set above:
+
+```
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification
+KF_FOOD:F001	apple	skos:exactMatch	FOODON:00002473	apple (whole)	semapv:ManualMappingCuration
+```
+
+(not repeating the mapping set metadata _brevitatis causa_) could get assigned
+an identifier like `example1:F001_exact_FOODON2473` – constructed by some
+informal derivation of the subject ID (`F001`), the predicate ID (`exact`), and
+the object ID (`FOODON2473`).
+
+This might be perceived as useful to a human curator, as the record identifier
+immediately gives a sense of what the record is about. It must be noted,
+however, that embedding any kind of meaning into an identifier is generally a
+bad idea
+([McMurry _et al_., 2017](https://doi.org/10.1371/journal.pbio.2001414)).
+
+#### Content-derived identifiers
+
+An identifier can be automatically derived from the record by running the record
+through some kind of condensation (“hash”) function that returns a value
+calculcated in such a way that the probability that two different records could
+yield the same value can be considered negligible.
+
+The SSSOM specification defines [such a function](spec-support-hashing.md).
+
+While the resulting value may appear meaningless, and not different from a
+randomly picked number, it represents a non-opaque identifier nonetheless
+because the value is still directly dependent on the content of the record.
+
+##### Content-derived identifiers considered harmful
+
+As noted at the very beginning of this page, the SSSOM specification is
+non-prescriptive about how identifiers should be minted. It neither mandates nor
+forbids any particular method, and all of the methods listed above (as well as
+other methods not listed here) _can_ be used in a SSSOM mapping set.
+
+However, the author of those lines strongly feels that content-derived
+identifiers are a particularly bad idea, for the reasons given in this section.
+
+**(A)** Content-derived identifiers make it impossible to write a mapping set
+entirely by hand. The hash of a mapping record cannot be realistically computed
+in someone’s head, whoever is editing the mapping will have to use a dedicated
+tool to produce it. This breaks an important promise of SSSOM, which is that one
+can always manually craft a SSSOM set with no specialised tooling at all – just
+a plain old spreadsheet software.
+
+**(B)** Content-derived identifiers are at risk of becoming “out-of-sync” with
+the records they supposedly identify. If an editor modifies the record in any
+way but forgets to re-run the ID-generating procedure, then they’ll end up with
+identifiers that are no longer really derived from the content of the record.
+
+**(C)** Content-derived identifiers deprive the set’s creators of the freedom to
+decide the difference between “updating an existing record” and “creating a new
+record”, because in fact there is no such thing as “updating a record” when
+using content-derived identifiers – any change to a record would cause the
+identifier to change, in effect always creating a _new_ independent record.
+
+**(D)** As a direct consequence of **C**, content-derived identifiers are not
+_stable_, because again any change to the record (even a semantically
+meaningless change like fixing a typo) would cause the identifier to change.
+This is turn means, for example, that consumers of records with content-derived
+identifiers cannot _reliably_ refer to them, because the identifiers may change
+at any time for even the slightest change made to the records.
+
+**(E)** The instability of content-derived identifiers is even worse in the
+specific case of SSSOM, because the content of a SSSOM record could change
+because of something that is out of the control of the record’s creator.
+
+Consider the following record:
+
+```
+subject_id  subject_label   predicate_id    object_id   object_label
+FBbt:00000015   thorax  semapv:crossSpeciesExactMatch   UBERON:6000015  insect thorax
+```
+
+and now let’s imagine that Uberon curators decide to rename UBERON:6000015 from
+“insect thorax” to “thorax sensu Insecta” (because they decided they prefer this
+way of mentioning the species within the label). The next time the mapping is
+updated to ensure it is using the latest labels, the record thus becomes:
+
+```
+subject_id  subject_label   predicate_id    object_id   object_label
+FBbt:00000015   thorax  semapv:crossSpeciesExactMatch   UBERON:6000015  thorax sensu Insecta
+```
+
+In this scenario, the _meaning_ of the record has not changed at all.
+UBERON:6000015 still represents the same concept as before, so this record still
+represents the very same mapping between the very same entities. And yet,
+because the _label_ of UBERON:6000015 has changed (something that the creator of
+the set has no control upon), if records were identified using content-derived
+identifiers we would have to consider the second record as a _different entity_,
+identified with a different identifier, than the first.
+
+Overall, content-derived identifiers can only be viable if some very specific
+conditions are met:
+
+- the data store (be it a database, a file, or whatever) where records are
+  stored must be **append-only**; that is, it must not be possible to delete or
+  modify existing records, you can only _add_ new records;
+- whenever a new record is created by deriving from an existing record, there
+  must be a way to get to the original record from the new record.
+
+_If_ you use SSSOM that way, then _maybe_ content-derived identifiers can be
+fine for your use case. Otherwise, you should stick to meaningless, opaque
+identifiers that are not tied to the content of the record.

--- a/src/docs/spec-intro.md
+++ b/src/docs/spec-intro.md
@@ -2,10 +2,11 @@
 
 This document is the official specification for the SSSOM standard.
 
-It is divided in two sections covering the two different components of the standard:
+It is divided in three sections covering the three different components of the standard:
 
 * the specification for the [data model](spec-model.md), to manipulate SSSOM mappings and mapping sets in your programs;
-* the specification for the [serialisation formats](spec-formats.md), to read, write, and exchange SSSOM mapping sets.
+* the specification for the [serialisation formats](spec-formats.md), to read, write, and exchange SSSOM mapping sets;
+* the specification for [supporting functions](spec-support.md) to help manipulating SSSOM mappings and mapping sets.
 
 Both sections are _normative_.
 

--- a/src/docs/spec-support-hashing.md
+++ b/src/docs/spec-support-hashing.md
@@ -1,0 +1,191 @@
+# Hashing a SSSOM mapping record
+
+SSSOM implementations SHOULD provide a function to compute a hash on a
+SSSOM mapping record. That function is hereafter called “the SSSOM
+hashing function” and defined below.
+
+## Rationale and purpose
+The SSSOM hashing function defined here is intended to allow mapping
+records to be quickly compared and, in particular, to quickly determine
+whether two records are identical.
+
+The function is intended for **interoperability** between SSSOM
+implementations. Its point is to ensure that one can always compute the
+same hash for the same mapping record regardless of which SSSOM
+implementation is used.
+
+When an implementation needs to assert whether two records are identical
+**for its own internal purposes** (for example, to store records into a
+hash table), it may use whatever method is best suited without regard
+for the SSSOM hashing function.
+
+## Hashing procedure
+
+The general principle of the SSSOM hashing function is to compute a
+ZBase32-encoded SHA2-256 hash of a canonical S-expression representing
+the mapping record.
+
+### Step 0: Propagate all condensed slots
+If the mapping set the mapping record to hash belongs to contains
+condensed slots, they MUST be propagated to the mapping record [as per
+the standard rules](spec-model.md#propagation).
+
+### Step 1: Turn the mapping record into a canonical S-expression
+This step creates a representation of the mapping record into a
+canonical S-expression as per [RFC 9804](https://www.rfc-editor.org/rfc/rfc9804#name-canonical-representation).
+
+The S-expression MUST be assembled as follows:
+
+1. Start with `(7:mapping(`,
+2. Iterate over all slots of the `Mapping` class, in the order in which
+they are [listed](../Mapping/#slots) in the LinkML model. Exclude the
+`record_id` slot and the `mapping_cardinality` slot. For all other
+slots:
+    1. If the slot has no value for the mapping record to hash, skip to
+    next slot.
+    2. Append to the S-expression `(N:SLOTNAME`, where _SLOTNAME_ is the
+    LinkML name for the slot and _N_ is the length of the slot name (so,
+    for rxample, `(10:subject_id`, `(9:author_id`, `(10:confidence`,
+    etc.).
+    3. If the slot is defined as a multi-valued slot (and even if it has
+    only one value in the mapping record to hash):
+        1. Append `(`.
+        2. Sort the list of values in lexicographical order and iterate
+        over the sorted values. For each value _V_, append `N:V`, where
+        _N_ is the length of _V_.
+        c. Append `)`.
+    4. If the slot is typed as a floating point number (e.g.
+    `confidence`), convert the value to a string _V_ by truncating the
+    floating point number to up to 3 digits after the decimal point,
+    rounding the last digit to the nearest neighbour (rounding up if
+    both neighbours are equidistant). Then append `N:V`, where _N_ is
+    the length of _V_.
+    5. If the slot is typed as an enumeration (e.g. `subject_type`),
+    append `N:ENUMVALUE`, where _ENUMVALUE_ is the allowed value in the
+    enumeration as specified in the LinkML model, and _N_ is the length
+    of _ENUMVALUE_ (e.g. `9:owl class` for a possible value for the
+    `subject_type` slot).
+    6. If the slot is typed as a date, append `10:YYYY-MM-DD`, where
+    _YYYY-MM-DD_ is the representation of the value in ISO-8601 format.
+    7. If the slot is typed as an entity reference, ensure the value is
+    expanded according to the mapping set’s prefix map and append `N:V`,
+    where _V_ is the expanded reference and _N_ is the length of the
+    expanded reference.
+    8. If the slot is of any other type, append `N:V`, where _V_ is the
+    string value of the slot and _N_ is the length of the string value.
+    9. Append `)`.
+3. If the implementation support [extension slots](spec-model.md#non-standard-slots)
+and the mapping record does have such slots:
+    1. Append `(10:extensions(`.
+    2. Sort extension values by their properties in lexicographical
+    order.
+    3. For each extension value:
+        1. Append `(N:PROP`, where _PROP_ is the property identifying
+        the extension and _N_ is the length of the property.
+        2. Append `N:V`, where _V_ is the extension value proper and _N_
+        its length.
+    4. Append `))`.
+4. Append `))`.
+
+### Step 2: Compute the SHA2-256 hash of the S-expression
+Encore the S-expression assembled in step 1 into UTF-8 (if it was not
+already assembled directly in UTF-8). Then hash the array of bytes
+containing the UTF-8 representation of the S-expression using the
+standard SHA2-256 hash function as defined in
+[NIST FIPS-180-4](https://doi.org/10.6028/NIST.FIPS.180-4).
+
+### Step 3: Encode the hash into a ZBase32 string
+Encode the hash computed in step 2 into its representation in the
+ZBase32 encoding ([RFC 6189](https://tools.ietf.org/html/rfc6189#section-5.1.6)).
+
+## Example
+
+> This section is not normative. It provides a step-by-step example of
+how to apply the above procedure.
+
+Given the following mapping record (in JSON format):
+
+```json
+{"subject_id": "http://purl.obolibrary.org/obo/FBbt_00001234",
+ "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
+ "object_id": "http://purl.obolibrary.org/obo/UBERON_0005678",
+ "mapping_justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
+ "creator_id": [
+    "https://orcid.org/0000-0000-5678-1234",
+    "https://orcid.org/0000-0000-1234-5678"
+ ]}
+```
+
+Applying step 1 of the above procedure would yield the following
+canonical S-expression (**whitespaces added for clarity**, they MUST NOT
+appear in the actual S-expression):
+
+```
+(7:mapping(
+           (10:subject_id44:http://purl.obolibrary.org/obo/FBbt_00001234)
+           (12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)
+           (9:object_id45:http://purl.obolibrary.org/obo/UBERON_0005678)
+           (21:mapping_justification51:https://w3id.org/semapv/vocab/ManualMappingCuration)
+           (10:creator_id(
+                          37:https://orcid.org/0000-0000-1234-5678
+                          37:https://orcid.org/0000-0000-5678-1234
+            ))
+))
+```
+
+Applying the SHA2-256 hash function to the above S-expression would
+yield the following hash (in hexadecimal):
+`e3bc1b4b586c6e86d0caf369d49c161163e255c4a779821f448a8e4fbd616522`.
+
+Finally, encoding the binary SHA2-256 hash in ZBase32 would yield the
+following final value:
+`hq6bs14aptzepwgk6pw7j8ysnft6riqrw7har84rtk8r9xmbcwty`.
+
+## Test vectors
+
+> This section is not normative. It provides examples of SSSOM mapping
+records along with the corresponding hash value.
+
+```json
+{"subject_id": "https://kewl-foodie.inc/food/F001",
+ "subject_label": "apple",
+ "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
+ "object_id": "http://purl.obolibrary.org/obo/FOODON_00002473",
+ "object_label": "apple (whole)",
+ "mapping_justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
+ "author_id": [
+   "https://orcid.org/0000-0002-7356-1779"
+ ],
+ "subject_source": "https://kewl-foodie.inc/food/DB",
+ "object_source": "https://www.wikidata.org/wiki/Q55118395",
+ "object_source_version": "http://purl.obolibrary.org/obo/foodon/releases/2022-02-01/foodon.owl",
+ "mapping_date": "2022-05-02",
+ "confidence": 0.95
+}
+```
+
+Hash value: `x4m9kcj8yjrrxh8ozwt83bkxcequb3fjqsamu9yyejyqft1gowao`
+
+```json
+{"record_id": "https://example.org/sets/record-id#0000001",
+ "subject_id": "http://purl.obolibrary.org/obo/FBbt_0009124",
+ "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
+ "object_id": "http://purl.obolibrary.org/obo/UBERON_0000003",
+ "mapping_justification": "https://w3id.org/semapv/vocab/LexicalMatching"
+}
+```
+
+Hash value: `qn1bra45hjtazt664husfgah5ewzo3oamh4swj5gomuka88rrqgo`
+
+```json
+{"subject_id": "http://purl.obolibrary.org/obo/HP_0009124",
+ "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
+ "object_id": "http://purl.obolibrary.org/obo/MP_0000003",
+ "mapping_justification": "https://w3id.org/semapv/vocab/LexicalSimilarityThresholdMatching",
+ "mapping_provider": "https://w3id.org/sssom/core_team",
+ "similarity_score": 0.8,
+ "similarity_measure": "wikidata:Q865360"
+}
+```
+
+Hash value: `is395b9nwm1rnz3nwkm89nmf563uw48sjspsx7ua8snjqzwz15ty`

--- a/src/docs/spec-support-hashing.md
+++ b/src/docs/spec-support-hashing.md
@@ -57,9 +57,8 @@ slots:
     4. If the slot is typed as a floating point number (e.g.
     `confidence`), convert the value to a string _V_ by truncating the
     floating point number to up to 3 digits after the decimal point,
-    rounding the last digit to the nearest neighbour (rounding up if
-    both neighbours are equidistant). Then append `N:V`, where _N_ is
-    the length of _V_.
+    rounding the last digit half away from zero. Then append `N:V`,
+    where _N_ is the length of _V_.
     5. If the slot is typed as an enumeration (e.g. `subject_type`),
     append `N:ENUMVALUE`, where _ENUMVALUE_ is the allowed value in the
     enumeration as specified in the LinkML model, and _N_ is the length
@@ -82,10 +81,25 @@ and the mapping record does have such slots:
     3. For each extension value:
         1. Append `(N:PROP`, where _PROP_ is the property identifying
         the extension and _N_ is the length of the property.
-        2. Append `N:V`, where _V_ is the extension value proper and _N_
-        its length.
+        2. Use the table below to transform the extension value into a
+        string _V_ based on the declared type of the extension.
+        3. Append `N:V`, where _N_ is the length of the string value _V_.
     4. Append `))`.
 4. Append `))`.
+
+Converting extension values to string:
+
+| Declared extension type | Conversion to string |
+| ----------------------- | -------------------- |
+| `xsd:string`            | No conversion needed, use the value directly |
+| `xsd:integer`           | Base 10 representation of the integer value |
+| `xsd:double`            | Truncate the number to up to 3 digits after the decimal point, round the last digit half away from zero |
+| `xsd:boolean`           | `true` or `false` |
+| `xsd:date`              | ISO-8601 representation: `YYYY-MM-DD` |
+| `xsd:datetime`          | ISO-8601 representation: `YYYY-MM-DDThh:mm:ssTZ` where `TZ` is the zone offset (e.g. `+01:00` or `-06:30`) |
+| `xsd:anyURI`            | No conversion needed, use the value directly |
+| `linkml:uriOrCurie`     | Expand the value according to the set’s prefix map |
+| any other type          | unspecified |
 
 ### Step 2: Compute the SHA2-256 hash of the S-expression
 Encore the S-expression assembled in step 1 into UTF-8 (if it was not

--- a/src/docs/spec-support-hashing.md
+++ b/src/docs/spec-support-hashing.md
@@ -103,22 +103,22 @@ ZBase32 encoding ([RFC 6189](https://tools.ietf.org/html/rfc6189#section-5.1.6))
 > This section is not normative. It provides a step-by-step example of
 how to apply the above procedure.
 
-Given the following mapping record (in JSON format):
+Given the following mapping set in SSSOM/TSV format:
 
-```json
-{"subject_id": "http://purl.obolibrary.org/obo/FBbt_00001234",
- "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
- "object_id": "http://purl.obolibrary.org/obo/UBERON_0005678",
- "mapping_justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
- "creator_id": [
-    "https://orcid.org/0000-0000-5678-1234",
-    "https://orcid.org/0000-0000-1234-5678"
- ]}
+```
+#curie_map:
+#  FBbt: http://purl.obolibrary.org/obo/FBbt_
+#  UBERON: http://purl.obolibrary.org/obo/UBERON_
+#  orcid: https://orcid.org/
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+subject_id	predicate_id	object_id	mapping_justification	creator_id
+FBbt:00001234	skos:exactMatch	UBERON:0005678	semapv:ManualMappingCuration	orcid:0000-0000-5678-1234|orcid:0000-0000-1234-5678
 ```
 
-Applying step 1 of the above procedure would yield the following
-canonical S-expression (**whitespaces added for clarity**, they MUST NOT
-appear in the actual S-expression):
+Applying step 1 of the above procedure to the only mapping record of
+that set would yield the following canonical S-expression (**whitespaces
+added for clarity**, they MUST NOT appear in the actual S-expression):
 
 ```
 (7:mapping(
@@ -144,48 +144,99 @@ following final value:
 ## Test vectors
 
 > This section is not normative. It provides examples of SSSOM mapping
-records along with the corresponding hash value.
+sets along with the canonical S-expression and the ZBase32-encoded hash
+value of the set’s only record.
 
-```json
-{"subject_id": "https://kewl-foodie.inc/food/F001",
- "subject_label": "apple",
- "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
- "object_id": "http://purl.obolibrary.org/obo/FOODON_00002473",
- "object_label": "apple (whole)",
- "mapping_justification": "https://w3id.org/semapv/vocab/ManualMappingCuration",
- "author_id": [
-   "https://orcid.org/0000-0002-7356-1779"
- ],
- "subject_source": "https://kewl-foodie.inc/food/DB",
- "object_source": "https://www.wikidata.org/wiki/Q55118395",
- "object_source_version": "http://purl.obolibrary.org/obo/foodon/releases/2022-02-01/foodon.owl",
- "mapping_date": "2022-05-02",
- "confidence": 0.95
-}
+**Source set:**
+```
+#curie_map:
+#  FOODON: http://purl.obolibrary.org/obo/FOODON_
+#  KF_FOOD: https://kewl-foodie.ince/food/
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#  wikidata: https://www.wikidata.org/wiki/
+#subject_source: KF_FOOD:DB
+#object_source: wikidata:Q55118395
+#object_source_version: http://purl.obolibrary.org/obo/foodon/releases/2022-02-01/foodon.owl
+subject_id	predicate_id	object_id	mapping_justification	confidence	mapping_date
+KF_FOOD:F001	skos:exactMatch	FOODON:00002473	semapv:ManualMappingCuration	0.95	2022-05-02
 ```
 
-Hash value: `x4m9kcj8yjrrxh8ozwt83bkxcequb3fjqsamu9yyejyqft1gowao`
-
-```json
-{"record_id": "https://example.org/sets/record-id#0000001",
- "subject_id": "http://purl.obolibrary.org/obo/FBbt_0009124",
- "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
- "object_id": "http://purl.obolibrary.org/obo/UBERON_0000003",
- "mapping_justification": "https://w3id.org/semapv/vocab/LexicalMatching"
-}
+S-expression:
+```
+(7:mapping((10:subject_id34:https://kewl-foodie.ince/food/F001)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id46:http://purl.obolibrary.org/obo/FOODON_00002473)(21:mapping_justification51:https://w3id.org/semapv/vocab/ManualMappingCuration)(14:subject_source32:https://kewl-foodie.ince/food/DB)(13:object_source39:https://www.wikidata.org/wiki/Q55118395)(21:object_source_version68:http://purl.obolibrary.org/obo/foodon/releases/2022-02-01/foodon.owl)(12:mapping_date10:2022-05-02)(10:confidence4:0.95)))
+```
+Hash value:
+```
+cdxs1je5rcwpiqnarmojsqmxmpfe9tj43sbahp8u6txk5rssoduo
 ```
 
-Hash value: `qn1bra45hjtazt664husfgah5ewzo3oamh4swj5gomuka88rrqgo`
-
-```json
-{"subject_id": "http://purl.obolibrary.org/obo/HP_0009124",
- "predicate_id": "http://www.w3.org/2004/02/skos/core#exactMatch",
- "object_id": "http://purl.obolibrary.org/obo/MP_0000003",
- "mapping_justification": "https://w3id.org/semapv/vocab/LexicalSimilarityThresholdMatching",
- "mapping_provider": "https://w3id.org/sssom/core_team",
- "similarity_score": 0.8,
- "similarity_measure": "wikidata:Q865360"
-}
+**Source set:**
+```
+#curie_map:
+#  FBbt: http://purl.obolibrary.org/obo/FBbt_
+#  UBERON: http://purl.obolibrary.org/obo/UBERON_
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#  example: https://example.org/sets/record-id#
+record_id	subject_id	predicate_id	object_id	mapping_justification
+example:0000001	FBbt:0009124	skos:exactMatch	UBERON:0000003	semapv:LexicalMatching
 ```
 
-Hash value: `is395b9nwm1rnz3nwkm89nmf563uw48sjspsx7ua8snjqzwz15ty`
+S-expression:
+```
+(7:mapping((10:subject_id43:http://purl.obolibrary.org/obo/FBbt_0009124)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id45:http://purl.obolibrary.org/obo/UBERON_0000003)(21:mapping_justification45:https://w3id.org/semapv/vocab/LexicalMatching)))
+```
+Hash value:
+```
+qn1bra45hjtazt664husfgah5ewzo3oamh4swj5gomuka88rrqgo
+```
+
+**Source set:**
+```
+#curie_map:
+#  HP: http://purl.obolibrary.org/obo/HP_
+#  MP: http://purl.obolibrary.org/obo/MP_
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#mapping_provider: https://w3id.org/sssom/core_team
+subject_id	predicate_id	object_id	mapping_justification	similarity_score
+HP:0009124	skos:exactMatch	MP:0000003	semapv:LexicalSimilarityThresholdMatching	0.8
+```
+
+S-expression:
+```
+(7:mapping((10:subject_id41:http://purl.obolibrary.org/obo/HP_0009124)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id41:http://purl.obolibrary.org/obo/MP_0000003)(21:mapping_justification64:https://w3id.org/semapv/vocab/LexicalSimilarityThresholdMatching)(16:mapping_provider32:https://w3id.org/sssom/core_team)(16:similarity_score3:0.8)))
+```
+Hash value:
+```
+bsat1g1mxe564n5rtoy5usdifybheqxgpes53rtbrue5uu3ac19o
+```
+
+**Source set:**
+```
+#curie_map:
+#  COMENT: https://example.com/entities/
+#  EXPROP: https://example.org/properties/
+#  ORGENT: https://example.org/entities/
+#  semapv: https://w3id.org/semapv/vocab/
+#  skos: http://www.w3.org/2004/02/skos/core#
+#extension_definitions:
+#  - slot_name: ext_bar
+#    property: EXPROP:barProperty
+#    type_hint: xsd:integer
+#  - slot_name: ext_baz
+#    property: EXPROP:bazProperty
+#    type_hint: linkml:Uriorcurie
+subject_id	subject_label	predicate_id	object_id	object_label	mapping_justification	ext_bar	ext_baz
+ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration	111	ORGENT:BAZ_0001
+```
+
+S-expression:
+```
+(7:mapping((10:subject_id33:https://example.org/entities/0001)(13:subject_label5:alice)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#closeMatch)(9:object_id33:https://example.com/entities/0011)(12:object_label5:alpha)(21:mapping_justification51:https://w3id.org/semapv/vocab/ManualMappingCuration)(10:extensions((42:https://example.org/properties/barProperty3:111)(42:https://example.org/properties/bazProperty37:https://example.org/entities/BAZ_0001)))))
+```
+Hash value:
+```
+o5tsbozxxc6i66nezy7rm679waam1f9mxbemqpbyeyiz4q53sqjo
+```

--- a/src/docs/spec-support-hashing.md
+++ b/src/docs/spec-support-hashing.md
@@ -1,121 +1,120 @@
 # Hashing a SSSOM mapping record
 
-SSSOM implementations SHOULD provide a function to compute a hash on a
-SSSOM mapping record. That function is hereafter called “the SSSOM
-hashing function” and defined below.
+SSSOM implementations SHOULD provide a function to compute a hash on a SSSOM
+mapping record. That function is hereafter called “the SSSOM hashing function”
+and defined below.
 
 ## Rationale and purpose
-The SSSOM hashing function defined here is intended to allow mapping
-records to be quickly compared and, in particular, to quickly determine
-whether two records are identical.
 
-The function is intended for **interoperability** between SSSOM
-implementations. Its point is to ensure that one can always compute the
-same hash for the same mapping record regardless of which SSSOM
-implementation is used.
+The SSSOM hashing function defined here is intended to allow mapping records to
+be quickly compared and, in particular, to quickly determine whether two records
+are identical.
 
-When an implementation needs to assert whether two records are identical
-**for its own internal purposes** (for example, to store records into a
-hash table), it may use whatever method is best suited without regard
-for the SSSOM hashing function.
+The function is intended for **interoperability** between SSSOM implementations.
+Its point is to ensure that one can always compute the same hash for the same
+mapping record regardless of which SSSOM implementation is used.
+
+When an implementation needs to assert whether two records are identical **for
+its own internal purposes** (for example, to store records into a hash table),
+it may use whatever method is best suited without regard for the SSSOM hashing
+function.
 
 ## Hashing procedure
 
 The general principle of the SSSOM hashing function is to compute a
-ZBase32-encoded SHA2-256 hash of a canonical S-expression representing
-the mapping record.
+ZBase32-encoded SHA2-256 hash of a canonical S-expression representing the
+mapping record.
 
 ### Step 0: Propagate all condensed slots
-If the mapping set the mapping record to hash belongs to contains
-condensed slots, they MUST be propagated to the mapping record [as per
-the standard rules](spec-model.md#propagation).
+
+If the mapping set the mapping record to hash belongs to contains condensed
+slots, they MUST be propagated to the mapping record
+[as per the standard rules](spec-model.md#propagation).
 
 ### Step 1: Turn the mapping record into a canonical S-expression
-This step creates a representation of the mapping record into a
-canonical S-expression as per [RFC 9804](https://www.rfc-editor.org/rfc/rfc9804#name-canonical-representation).
+
+This step creates a representation of the mapping record into a canonical
+S-expression as per
+[RFC 9804](https://www.rfc-editor.org/rfc/rfc9804#name-canonical-representation).
 
 The S-expression MUST be assembled as follows:
 
-1. Start with `(7:mapping(`,
-2. Iterate over all slots of the `Mapping` class, in the order in which
-they are [listed](../Mapping/#slots) in the LinkML model. Exclude the
-`record_id` slot and the `mapping_cardinality` slot. For all other
-slots:
-    1. If the slot has no value for the mapping record to hash, skip to
-    next slot.
-    2. Append to the S-expression `(N:SLOTNAME`, where _SLOTNAME_ is the
-    LinkML name for the slot and _N_ is the length of the slot name (so,
-    for rxample, `(10:subject_id`, `(9:author_id`, `(10:confidence`,
-    etc.).
-    3. If the slot is defined as a multi-valued slot (and even if it has
-    only one value in the mapping record to hash):
+1.  Start with `(7:mapping(`.
+2.  Iterate over all slots of the `Mapping` class, in the order in which they
+    are [listed](../Mapping/#slots) in the LinkML model. Exclude the `record_id`
+    slot and the `mapping_cardinality` slot. For all other slots:
+    1. If the slot has no value for the mapping record to hash, skip to next
+       slot.
+    2. Append to the S-expression `(N:SLOTNAME`, where _SLOTNAME_ is the LinkML
+       name for the slot and _N_ is the length of the slot name (so, for
+       rxample, `(10:subject_id`, `(9:author_id`, `(10:confidence`, etc.).
+    3. If the slot is defined as a multi-valued slot (and even if it has only
+       one value in the mapping record to hash):
         1. Append `(`.
-        2. Sort the list of values in lexicographical order and iterate
-        over the sorted values. For each value _V_, append `N:V`, where
-        _N_ is the length of _V_.
-        c. Append `)`.
-    4. If the slot is typed as a floating point number (e.g.
-    `confidence`), convert the value to a string _V_ by truncating the
-    floating point number to up to 3 digits after the decimal point,
-    rounding the last digit half away from zero. Then append `N:V`,
-    where _N_ is the length of _V_.
-    5. If the slot is typed as an enumeration (e.g. `subject_type`),
-    append `N:ENUMVALUE`, where _ENUMVALUE_ is the allowed value in the
-    enumeration as specified in the LinkML model, and _N_ is the length
-    of _ENUMVALUE_ (e.g. `9:owl class` for a possible value for the
-    `subject_type` slot).
+        2. Sort the list of values in lexicographical order and iterate over the
+           sorted values. For each value _V_, append `N:V`, where _N_ is the
+           length of _V_.
+        3. Append `)`.
+    4. If the slot is typed as a floating point number (e.g. `confidence`),
+       convert the value to a string _V_ by truncating the floating point number
+       to up to 3 digits after the decimal point, rounding the last digit half
+       away from zero. Then append `N:V`, where _N_ is the length of _V_.
+    5. If the slot is typed as an enumeration (e.g. `subject_type`), append
+       `N:ENUMVALUE`, where _ENUMVALUE_ is the allowed value in the enumeration
+       as specified in the LinkML model, and _N_ is the length of _ENUMVALUE_
+       (e.g. `9:owl class` for a possible value for the `subject_type` slot).
     6. If the slot is typed as a date, append `10:YYYY-MM-DD`, where
-    _YYYY-MM-DD_ is the representation of the value in ISO-8601 format.
-    7. If the slot is typed as an entity reference, ensure the value is
-    expanded according to the mapping set’s prefix map and append `N:V`,
-    where _V_ is the expanded reference and _N_ is the length of the
-    expanded reference.
-    8. If the slot is of any other type, append `N:V`, where _V_ is the
-    string value of the slot and _N_ is the length of the string value.
+       _YYYY-MM-DD_ is the representation of the value in ISO-8601 format.
+    7. If the slot is typed as an entity reference, ensure the value is expanded
+       according to the mapping set’s prefix map and append `N:V`, where _V_ is
+       the expanded reference and _N_ is the length of the expanded reference.
+    8. If the slot is of any other type, append `N:V`, where _V_ is the string
+       value of the slot and _N_ is the length of the string value.
     9. Append `)`.
-3. If the implementation support [extension slots](spec-model.md#non-standard-slots)
-and the mapping record does have such slots:
+3.  If the implementation support
+    [extension slots](spec-model.md#non-standard-slots) and the mapping record
+    does have such slots:
     1. Append `(10:extensions(`.
-    2. Sort extension values by their properties in lexicographical
-    order.
+    2. Sort extension values by their properties in lexicographical order.
     3. For each extension value:
-        1. Append `(N:PROP`, where _PROP_ is the property identifying
-        the extension and _N_ is the length of the property.
-        2. Use the table below to transform the extension value into a
-        string _V_ based on the declared type of the extension.
-        3. Append `N:V`, where _N_ is the length of the string value _V_.
+        1. Append `(N:PROP`, where _PROP_ is the property identifying the
+           extension and _N_ is the length of the property.
+        2. Use the table below to transform the extension value into a string
+           _V_ based on the declared type of the extension.
+        3. Append `N:V)`, where _N_ is the length of the string value _V_.
     4. Append `))`.
-4. Append `))`.
+4.  Append `))`.
 
 Converting extension values to string:
 
-| Declared extension type | Conversion to string |
-| ----------------------- | -------------------- |
-| `xsd:string`            | No conversion needed, use the value directly |
-| `xsd:integer`           | Base 10 representation of the integer value |
-| `xsd:double`            | Truncate the number to up to 3 digits after the decimal point, round the last digit half away from zero |
-| `xsd:boolean`           | `true` or `false` |
-| `xsd:date`              | ISO-8601 representation: `YYYY-MM-DD` |
+| Declared extension type | Conversion to string                                                                                       |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `xsd:string`            | No conversion needed, use the value directly                                                               |
+| `xsd:integer`           | Base 10 representation of the integer value                                                                |
+| `xsd:double`            | Truncate the number to up to 3 digits after the decimal point, round the last digit half away from zero    |
+| `xsd:boolean`           | `true` or `false`                                                                                          |
+| `xsd:date`              | ISO-8601 representation: `YYYY-MM-DD`                                                                      |
 | `xsd:datetime`          | ISO-8601 representation: `YYYY-MM-DDThh:mm:ssTZ` where `TZ` is the zone offset (e.g. `+01:00` or `-06:30`) |
-| `xsd:anyURI`            | No conversion needed, use the value directly |
-| `linkml:uriOrCurie`     | Expand the value according to the set’s prefix map |
-| any other type          | unspecified |
+| `xsd:anyURI`            | No conversion needed, use the value directly                                                               |
+| `linkml:uriOrCurie`     | Expand the value according to the set’s prefix map                                                         |
+| any other type          | unspecified                                                                                                |
 
 ### Step 2: Compute the SHA2-256 hash of the S-expression
-Encore the S-expression assembled in step 1 into UTF-8 (if it was not
-already assembled directly in UTF-8). Then hash the array of bytes
-containing the UTF-8 representation of the S-expression using the
-standard SHA2-256 hash function as defined in
-[NIST FIPS-180-4](https://doi.org/10.6028/NIST.FIPS.180-4).
+
+Encore the S-expression assembled in step 1 into UTF-8 (if it was not already
+assembled directly in UTF-8). Then hash the array of bytes containing the UTF-8
+representation of the S-expression using the standard SHA2-256 hash function as
+defined in [NIST FIPS-180-4](https://doi.org/10.6028/NIST.FIPS.180-4).
 
 ### Step 3: Encode the hash into a ZBase32 string
-Encode the hash computed in step 2 into its representation in the
-ZBase32 encoding ([RFC 6189](https://tools.ietf.org/html/rfc6189#section-5.1.6)).
+
+Encode the hash computed in step 2 into its representation in the ZBase32
+encoding ([RFC 6189](https://tools.ietf.org/html/rfc6189#section-5.1.6)).
 
 ## Example
 
-> This section is not normative. It provides a step-by-step example of
-how to apply the above procedure.
+> This section is not normative. It provides a step-by-step example of how to
+> apply the above procedure.
 
 Given the following mapping set in SSSOM/TSV format:
 
@@ -130,9 +129,9 @@ subject_id	predicate_id	object_id	mapping_justification	creator_id
 FBbt:00001234	skos:exactMatch	UBERON:0005678	semapv:ManualMappingCuration	orcid:0000-0000-5678-1234|orcid:0000-0000-1234-5678
 ```
 
-Applying step 1 of the above procedure to the only mapping record of
-that set would yield the following canonical S-expression (**whitespaces
-added for clarity**, they MUST NOT appear in the actual S-expression):
+Applying step 1 of the above procedure to the only mapping record of that set
+would yield the following canonical S-expression (**whitespaces added for
+clarity**, they MUST NOT appear in the actual S-expression):
 
 ```
 (7:mapping(
@@ -147,21 +146,21 @@ added for clarity**, they MUST NOT appear in the actual S-expression):
 ))
 ```
 
-Applying the SHA2-256 hash function to the above S-expression would
-yield the following hash (in hexadecimal):
+Applying the SHA2-256 hash function to the above S-expression would yield the
+following hash (in hexadecimal):
 `e3bc1b4b586c6e86d0caf369d49c161163e255c4a779821f448a8e4fbd616522`.
 
-Finally, encoding the binary SHA2-256 hash in ZBase32 would yield the
-following final value:
-`hq6bs14aptzepwgk6pw7j8ysnft6riqrw7har84rtk8r9xmbcwty`.
+Finally, encoding the binary SHA2-256 hash in ZBase32 would yield the following
+final value: `hq6bs14aptzepwgk6pw7j8ysnft6riqrw7har84rtk8r9xmbcwty`.
 
 ## Test vectors
 
-> This section is not normative. It provides examples of SSSOM mapping
-sets along with the canonical S-expression and the ZBase32-encoded hash
-value of the set’s only record.
+> This section is not normative. It provides examples of SSSOM mapping sets
+> along with the canonical S-expression and the ZBase32-encoded hash value of
+> the set’s only record.
 
 **Source set:**
+
 ```
 #curie_map:
 #  FOODON: http://purl.obolibrary.org/obo/FOODON_
@@ -177,15 +176,19 @@ KF_FOOD:F001	skos:exactMatch	FOODON:00002473	semapv:ManualMappingCuration	0.95	2
 ```
 
 S-expression:
+
 ```
 (7:mapping((10:subject_id34:https://kewl-foodie.ince/food/F001)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id46:http://purl.obolibrary.org/obo/FOODON_00002473)(21:mapping_justification51:https://w3id.org/semapv/vocab/ManualMappingCuration)(14:subject_source32:https://kewl-foodie.ince/food/DB)(13:object_source39:https://www.wikidata.org/wiki/Q55118395)(21:object_source_version68:http://purl.obolibrary.org/obo/foodon/releases/2022-02-01/foodon.owl)(12:mapping_date10:2022-05-02)(10:confidence4:0.95)))
 ```
+
 Hash value:
+
 ```
 cdxs1je5rcwpiqnarmojsqmxmpfe9tj43sbahp8u6txk5rssoduo
 ```
 
 **Source set:**
+
 ```
 #curie_map:
 #  FBbt: http://purl.obolibrary.org/obo/FBbt_
@@ -198,15 +201,19 @@ example:0000001	FBbt:0009124	skos:exactMatch	UBERON:0000003	semapv:LexicalMatchi
 ```
 
 S-expression:
+
 ```
 (7:mapping((10:subject_id43:http://purl.obolibrary.org/obo/FBbt_0009124)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id45:http://purl.obolibrary.org/obo/UBERON_0000003)(21:mapping_justification45:https://w3id.org/semapv/vocab/LexicalMatching)))
 ```
+
 Hash value:
+
 ```
 qn1bra45hjtazt664husfgah5ewzo3oamh4swj5gomuka88rrqgo
 ```
 
 **Source set:**
+
 ```
 #curie_map:
 #  HP: http://purl.obolibrary.org/obo/HP_
@@ -219,15 +226,19 @@ HP:0009124	skos:exactMatch	MP:0000003	semapv:LexicalSimilarityThresholdMatching	
 ```
 
 S-expression:
+
 ```
 (7:mapping((10:subject_id41:http://purl.obolibrary.org/obo/HP_0009124)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#exactMatch)(9:object_id41:http://purl.obolibrary.org/obo/MP_0000003)(21:mapping_justification64:https://w3id.org/semapv/vocab/LexicalSimilarityThresholdMatching)(16:mapping_provider32:https://w3id.org/sssom/core_team)(16:similarity_score3:0.8)))
 ```
+
 Hash value:
+
 ```
 bsat1g1mxe564n5rtoy5usdifybheqxgpes53rtbrue5uu3ac19o
 ```
 
 **Source set:**
+
 ```
 #curie_map:
 #  COMENT: https://example.com/entities/
@@ -247,10 +258,13 @@ ORGENT:0001	alice	skos:closeMatch	COMENT:0011	alpha	semapv:ManualMappingCuration
 ```
 
 S-expression:
+
 ```
 (7:mapping((10:subject_id33:https://example.org/entities/0001)(13:subject_label5:alice)(12:predicate_id46:http://www.w3.org/2004/02/skos/core#closeMatch)(9:object_id33:https://example.com/entities/0011)(12:object_label5:alpha)(21:mapping_justification51:https://w3id.org/semapv/vocab/ManualMappingCuration)(10:extensions((42:https://example.org/properties/barProperty3:111)(42:https://example.org/properties/bazProperty37:https://example.org/entities/BAZ_0001)))))
 ```
+
 Hash value:
+
 ```
 o5tsbozxxc6i66nezy7rm679waam1f9mxbemqpbyeyiz4q53sqjo
 ```

--- a/src/docs/spec-support.md
+++ b/src/docs/spec-support.md
@@ -1,0 +1,7 @@
+# SSSOM supporting functions
+
+This section defines functions and behaviours that SSSOM implementations
+should support to help users manipulate SSSOM mapping sets.
+
+* [Hashing mapping records](spec-support-hashing.md)
+* [Chaining rules](chaining-rules.md)


### PR DESCRIPTION
Resolves [#436]

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~
- [x] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

This PR adds a new section to the normative part of the website, intended for specifying stuff that are not part of the SSSOM data model nor of any of the SSSOM serialisation formats, but that should still be formally specified so that they can be implemented in the expected way by the various implementations.

The existing page about "chaining rules" is moved to that new section, as it does not really belong to the "data model".

Finally, the core of the PR is that a new page is added to the new section to define a standard SSSOM hashing function.

closes #436