### PR TITLE
Add sssom-pydantic to front page

### DIFF
--- a/src/doc-templates/frontpage.md.jinja2
+++ b/src/doc-templates/frontpage.md.jinja2
@@ -89,7 +89,8 @@ For mapping set metadata please see [here](MappingSet.md).
 **Related software**
 
 - [SSSOM-Java](https://incenp.org/dvlpt/sssom-java/) (reference implementation of the SSSOM standard in Java, most up to date with the current standard; provides a Java library, a command-line tool, and a ROBOT plugin)
-- [sssom-py](https://mapping-commons.github.io/sssom-py/) (an implementation of the standard, a toolkit and API for processing mappings, written in Python)
+- [sssom-py](https://mapping-commons.github.io/sssom-py/) (an implementation of the standard, a toolkit and API for processing mappings, written in Python using Pandas dataframes and/or LinkML objects as a primary data structure)
+- [sssom-pydantic](https://github.com/cthoyt/sssom-pydantic) (an implementation of the standard, a toolkit and API for processing mappings, written in Python using Pydantic as a primary data structure)
 - [sssom-js](https://www.npmjs.org/package/sssom-js) (an implementation of the SSSOM standard in JavaScript)
 
 ## The SSSOM Core Team


### PR DESCRIPTION
This PR adds a link to https://github.com/cthoyt/sssom-pydantic to the front page. It also slightly extends the sssom-py description to make (some of) the differences more visible