### PR TITLE
Mention the Mapping Sameness Identifier.

### DIFF
--- a/src/docs/record-identifiers.md
+++ b/src/docs/record-identifiers.md
@@ -153,7 +153,7 @@ Of note, the
 a proposed SSSOM-independent standard to compute an unique identifier for a
 mapping, is _not_ suitable as a SSSOM record identifier, because it may not be
 unique for any given record (on the contrary, it is explicitly designed to be
-identical for all records that have the same subject, the same predicate, and
+identical for all records that have the same subject, the same predicate (incl. possible negation modifier), and
 the same object, regardless of all other metadata).
 
 ##### Content-derived identifiers considered harmful

--- a/src/docs/record-identifiers.md
+++ b/src/docs/record-identifiers.md
@@ -148,6 +148,14 @@ While the resulting value may appear meaningless, and not different from a
 randomly picked number, it represents a non-opaque identifier nonetheless
 because the value is still directly dependent on the content of the record.
 
+Of note, the
+[Mapping Sameness Identifier](https://ts4nfdi.github.io/mapping-sameness-identifier/),
+a proposed SSSOM-independent standard to compute an unique identifier for a
+mapping, is _not_ suitable as a SSSOM record identifier, because it may not be
+unique for any given record (on the contrary, it is explicitly designed to be
+identical for all records that have the same subject, the same predicate, and
+the same object, regardless of all other metadata).
+
 ##### Content-derived identifiers considered harmful
 
 As noted at the very beginning of this page, the SSSOM specification is

--- a/src/docs/spec-support.md
+++ b/src/docs/spec-support.md
@@ -1,7 +1,12 @@
 # SSSOM supporting functions
 
-This section defines functions and behaviours that SSSOM implementations
-should support to help users manipulate SSSOM mapping sets.
+This section defines functions and behaviours that SSSOM implementations should
+support to help users manipulate SSSOM mapping sets.
 
-* [Hashing mapping records](spec-support-hashing.md)
-* [Chaining rules](chaining-rules.md)
+- [Hashing mapping records](spec-support-hashing.md)
+- [Chaining rules](chaining-rules.md)
+
+In addition, SSSOM implementations SHOULD also support the proposed
+[Mapping Sameness Identifier](https://ts4nfdi.github.io/mapping-sameness-identifier/)
+standard; that is, implementations SHOULD offer a way to obtain the Mapping
+Sameness Identifier for a given SSSOM mapping record.


### PR DESCRIPTION
Resolves [#535]

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- [ ] ~~tests have been added/updated (if applicable)~~
- [ ] ~~[CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~

This PR adds a reference to the [Mapping Sameness Identifier](https://ts4nfdi.github.io/mapping-sameness-identifier) proposed standard, and recommends that SSSOM implementations SHOULD support it.

It also adds a mention to that standard in the non-normative guidance about minting record identifiers, to explain that it is _not_ suitable as a record identifier.

closes #535.