### PR TITLE
Fix capitalisation of `linkml:Uriorcurie`.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,8 +71,10 @@ nav:
           - Set up a mapping registry/commons: mapping-commons.md
           - A basic guide for the SSSOM toolkit: toolkit.md
           - 5-Star Entity Mappings - Cheatsheet: 5star-mappings.md
-          - Matching tool implementation guide: matching-tool-implementation-guide.md
-          - How to gradually enrich OMOP mappings with SSSOM: tutorials/omop-mappings.md
+          - Matching tool implementation guide:
+              matching-tool-implementation-guide.md
+          - How to gradually enrich OMOP mappings with SSSOM:
+              tutorials/omop-mappings.md
           - How to assess mapping confidence: confidence-model.md
           - Identifying mapping records: record-identifiers.md
       - Reference:

--- a/src/docs/spec-formats-rdf.md
+++ b/src/docs/spec-formats-rdf.md
@@ -139,7 +139,7 @@ extension.
 The value of the extension MUST be represented:
 
 - as a named RDF resource, if the `type_hint` of the extension definition is
-  `linkml:uriOrCurie`;
+  `linkml:Uriorcurie`;
 - otherwise, as a literal of the type indicated by the `type_hint`.
 
 <a id="sssom-objects"></a>

--- a/src/docs/spec-support-hashing.md
+++ b/src/docs/spec-support-hashing.md
@@ -96,7 +96,7 @@ Converting extension values to string:
 | `xsd:date`              | ISO-8601 representation: `YYYY-MM-DD`                                                                      |
 | `xsd:datetime`          | ISO-8601 representation: `YYYY-MM-DDThh:mm:ssTZ` where `TZ` is the zone offset (e.g. `+01:00` or `-06:30`) |
 | `xsd:anyURI`            | No conversion needed, use the value directly                                                               |
-| `linkml:uriOrCurie`     | Expand the value according to the set’s prefix map                                                         |
+| `linkml:Uriorcurie`     | Expand the value according to the set’s prefix map                                                         |
 | any other type          | unspecified                                                                                                |
 
 ### Step 2: Compute the FNV64 hash of the S-expression


### PR DESCRIPTION
The proper URI for LinkML's `uriorcurie` type is `linkml:Uriorcurie`, *not* `linkml:uriOrCurie`.

- [x] `docs/` have been added/updated if necessary
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- ~~[ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~