### PR TITLE
Add "titles" to permissible values.

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -29,9 +29,11 @@ enums:
   sssom_version_enum:
     permissible_values:
       "1.0":
+        title: Version 1 0
         meaning: sssom:version1.0
         description: SSSOM specification version 1.0
       "1.1":
+        title: Version 1 1
         meaning: sssom:version1.1
         description: SSSOM specification version 1.1
   entity_type_enum:
@@ -89,32 +91,39 @@ enums:
   mapping_cardinality_enum:
     permissible_values:
       "1:1":
+        title: one to one
         description:
           Indicates the mapping record is about a one-to-one mapping, that is,
           the subject and the object are only mapped to each other, exclusive of
           any other subject or object.
       "1:n":
+        title: one to many
         description:
           Indicates the mapping record is about a one-to-many mapping, that is,
           the same subject is mapped to several different objects.
       "n:1":
+        title: many to one
         description:
           Indicates the mapping record is about a many-to-one mapping, that is,
           several different subjects are mapped to the same object.
       "n:n":
+        title: many to many
         description:
           Indicates the mapping record is about a many-to-many mapping, that is,
           the subject is mapped to several different objects and the object is
           mapped to several different subjects.
       "1:0":
+        title: one to none
         description:
           Indicates that the subject has no match in the object vocabulary. This
           value MUST only be used when the object_id is sssom:NoTermFound.
       "0:1":
+        title: none to one
         description:
           Indicates that the object has no match in the subject vocabulary. This
           value MUST only be used when the subject_id is sssom:NoTermFound.
       "0:0":
+        title: none to none
         description:
           Indicates that there is no match between the subject vocabulary and
           the object vocabulary. This value MUST only be used when both the


### PR DESCRIPTION
- ~~[ ] `docs/` have been added/updated if necessary~~
- [x] `make test` has been run locally
- ~~[ ] tests have been added/updated (if applicable)~~
- ~~[ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.~~

If you are proposing a change to the SSSOM metadata model, you must 

- ~~[ ] provide a full, working and valid example in `examples/`~~
- ~~[ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model~~
- ~~[ ] provide a link to a valid example in the `see_also` field of the linkml model~~
- ~~[ ] update the "Model changes across versions" (in `src/docs/spec-models.md`) accordingly~~
- [x] run SSSOM-Py test suite against the updated model

The `sssom_version_enum` and `mapping_cardinality_enum` enumerations contain permissible values (PVs) that by default are transformed into very unwieldy symbol names in many programming languages handled by LinkML generators.

For example, the `1:1` mapping cardinality value yields a symbol named `number_1COLON1` (in Pydantic and Typescript) or `NUMBER_1COLON1` (in Java). Likewise, the `1.0` SSSOM version value yields a symbol named `number_1FULL_STOP0` (Pydantic, Typescript) or `NUMBER_1FULL_STOP0` (Java).

This commit assigns to such PVs a `title` that the generators can use to derive the code symbols. For example, the `1.0` value for `sssom_version_enum` is assigned the "title" `Version 1 0`, yielding a much more convenient symbol named `Version_1_0` (Pydantic, Typescript) or `VERSION_1_0` (Java).

This has _no effect_ on which values are accepted for a given enumeration. This only produces more meaningful symbols in generated code.

This is a workaround until LinkML provides a more explicit way of specifying custom code symbols for weird enumeration values (see https://github.com/linkml/linkml/issues/3826).