### PR TITLE
Fix description for object_category in schema

### DIFF
--- a/src/sssom_schema/schema/sssom_schema.yaml
+++ b/src/sssom_schema/schema/sssom_schema.yaml
@@ -429,7 +429,7 @@ slots:
     recommended: true
   object_category:
     description:
-      The conceptual category to which the subject belongs to. This can be a
+      The conceptual category to which the object belongs to. This can be a
       string denoting the category or a term from a controlled vocabulary. This
       slot is deliberately underspecified. Conceptual categories can range from
       those that are found in general upper ontologies such as BFO (e.g.


### PR DESCRIPTION
Fix copy & paste typo in object_category.

"The conceptual category to which the **subject** belongs to." --> "The conceptual category to which the **object** belongs to."


- [ ] `docs/` have been added/updated if necessary
- [ ] `make test` has been run locally
- [ ] tests have been added/updated (if applicable)
- [ ] [CHANGELOG.md](https://github.com/mapping-commons/sssom/blob/master/CHANGELOG.md) has been updated.

If you are proposing a change to the SSSOM metadata model, you must 

- [ ] provide a full, working and valid example in `examples/`
- [ ] provide a link to the related GitHub issue in the `see_also` field of the linkml model
- [ ] provide a link to a valid example in the `see_also` field of the linkml model
- [ ] update the "Model changes across versions" (in `src/docs/spec-models.md`) accordingly
- [ ] run SSSOM-Py test suite against the updated model

